### PR TITLE
Fix API rate limiting with WS URL caching, connect guard, and unified backoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 .pytest_cache/
 .coverage
 htmlcov/
+uv.lock

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ automation:
 
 Both APIs use the same architecture: real-time WebSocket push with REST polling fallback. Each API has its own independent connection and rate limit budget.
 
-### Gardena Smart System API (~3,000 requests/month)
+### Gardena Smart System API (~10,000 requests/month)
 
 #### Startup (on every HA restart or integration reload)
 
@@ -523,10 +523,12 @@ Each button press or automation action is one API call. The 5-second throttle pr
 | Strategy | Detail |
 |----------|--------|
 | **WebSocket-first architecture** | Device state updates arrive in real time via persistent WebSocket connections. REST API polling is only a fallback. If the WebSocket drops, auto-reconnect with exponential backoff kicks in (30s → 30m). A **watchdog timer** checks every 60 seconds that the WebSocket is still receiving data — if silent for 5 minutes, the connection is forcibly recycled. |
+| **WebSocket URL caching** | The WebSocket URL obtained from the API is cached and reused across reconnects as long as the auth token is still valid. This eliminates an unnecessary `POST /websocket` call on every reconnect attempt. The cache is invalidated when the token expires or a connection attempt fails. |
+| **Connect guard** | An async lock prevents parallel WebSocket connect attempts (e.g. watchdog and poll cycle racing), avoiding duplicate API calls. |
 | **Adaptive polling interval** | When WebSocket is connected: **6-hour** health-check only. When WebSocket drops: **30 min** (Gardena) / **15 min** (Automower). |
-| **Graduated rate limit backoff** | If the API returns HTTP 429, polling backs off exponentially (5 min → 10 → 20 → 40 → 60 min max) and resets after a successful response. |
+| **Graduated rate limit backoff** | If any API call returns HTTP 429 — including token refresh and WebSocket URL requests — polling backs off exponentially (5 min → 10 → 20 → 40 → 60 min max) and resets after a successful response. |
 | **Command throttling** | A minimum **5-second interval** is enforced between consecutive commands to prevent automations from rapid-firing API calls. |
-| **Independent budgets** | The Gardena API (~3,000/month) and Automower API (~10,000/month) have separate rate limits. Using one does not affect the other. |
+| **Independent budgets** | Both the Gardena API and the Automower API allow ~10,000 requests/month each. Using one does not affect the other. |
 
 ### Tips for Avoiding Rate Limits
 

--- a/custom_components/gardena_smart_system/base_coordinator.py
+++ b/custom_components/gardena_smart_system/base_coordinator.py
@@ -102,6 +102,8 @@ class BaseSmartSystemCoordinator[DeviceT](DataUpdateCoordinator[dict[str, Device
         self._ws_reconnect_task: asyncio.Task[None] | None = None
         self._mqtt_bridge: Any = None
         self._ws_watchdog_unsub: CALLBACK_TYPE | None = None
+        self._cached_ws_url: str | None = None
+        self._ws_connect_lock = asyncio.Lock()
 
     # ── Public properties ──────────────────────────────────────────────
 
@@ -151,20 +153,9 @@ class BaseSmartSystemCoordinator[DeviceT](DataUpdateCoordinator[dict[str, Device
         except cfg.auth_error_type as err:
             raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
         except cfg.rate_limit_error_type as err:
-            self._rate_limit_hits += 1
-            backoff = min(
-                cfg.rate_limit_cooldown,
-                timedelta(minutes=5) * (2 ** (self._rate_limit_hits - 1)),
-            )
-            self.update_interval = backoff
-            _LOGGER.warning(
-                "Rate limited by %s API (hit #%d), backing off to %s",
-                cfg.api_label,
-                self._rate_limit_hits,
-                backoff,
-            )
+            self._apply_rate_limit_backoff(err)
             raise UpdateFailed(
-                f"Rate limited by {cfg.api_label} API, retrying in {backoff}: {err}"
+                f"Rate limited by {cfg.api_label} API, retrying in {self.update_interval}: {err}"
             ) from err
         except cfg.connection_error_type as err:
             raise UpdateFailed(f"Cannot connect to {cfg.api_label} API: {err}") from err
@@ -252,17 +243,44 @@ class BaseSmartSystemCoordinator[DeviceT](DataUpdateCoordinator[dict[str, Device
             del self._stale_miss_counts[device_id]
 
     async def _async_start_websocket(self, devices: dict[str, DeviceT]) -> None:
-        """Start the WebSocket for real-time updates."""
-        cfg = self._config
-        try:
-            ws_url = await self._async_get_ws_url(devices)
-        except (cfg.auth_error_type, cfg.connection_error_type, cfg.rate_limit_error_type) as err:
-            _LOGGER.warning(
-                "Could not obtain %s WebSocket URL, will rely on polling: %s",
-                cfg.api_label,
-                err,
+        """Start the WebSocket for real-time updates.
+
+        Protected by a lock to prevent parallel connect attempts (e.g. watchdog +
+        poll cycle racing).  The WebSocket URL is cached and reused as long as
+        the auth token is still valid; a fresh URL is fetched only when the token
+        was refreshed or the cached URL fails to connect.
+        """
+        if self._ws_connect_lock.locked():
+            _LOGGER.debug(
+                "%s WebSocket connect already in progress, skipping",
+                self._config.api_label,
             )
             return
+
+        async with self._ws_connect_lock:
+            await self._async_start_websocket_locked(devices)
+
+    async def _async_start_websocket_locked(self, devices: dict[str, DeviceT]) -> None:
+        """Inner WebSocket start logic (must be called under _ws_connect_lock)."""
+        cfg = self._config
+
+        # Reuse cached WS URL while the auth token is still valid
+        ws_url = self._cached_ws_url if self._auth.is_token_valid and self._cached_ws_url else None
+
+        if ws_url is None:
+            try:
+                ws_url = await self._async_get_ws_url(devices)
+            except cfg.rate_limit_error_type as err:
+                self._apply_rate_limit_backoff(err)
+                return
+            except (cfg.auth_error_type, cfg.connection_error_type) as err:
+                _LOGGER.warning(
+                    "Could not obtain %s WebSocket URL, will rely on polling: %s",
+                    cfg.api_label,
+                    err,
+                )
+                return
+            self._cached_ws_url = ws_url
 
         self._ws = self._create_websocket(
             auth=self._auth,
@@ -280,6 +298,8 @@ class BaseSmartSystemCoordinator[DeviceT](DataUpdateCoordinator[dict[str, Device
                 err,
             )
             self._ws = None
+            # Invalidate cached URL so the next attempt fetches a fresh one
+            self._cached_ws_url = None
             return
 
         self._ws_connected = True
@@ -310,6 +330,7 @@ class BaseSmartSystemCoordinator[DeviceT](DataUpdateCoordinator[dict[str, Device
         _LOGGER.error("%s WebSocket connection lost: %s", cfg.api_label, err)
         self._ws_connected = False
         self._ws = None
+        self._cached_ws_url = None
         self._stop_ws_watchdog()
         self.update_interval = self._custom_poll_interval or cfg.scan_interval
 
@@ -332,6 +353,28 @@ class BaseSmartSystemCoordinator[DeviceT](DataUpdateCoordinator[dict[str, Device
             err,
         )
         self._schedule_ws_reconnect()
+
+    def _apply_rate_limit_backoff(self, err: Exception) -> None:
+        """Apply exponential backoff for a rate-limit error.
+
+        Shared between the poll cycle (_async_update_data) and WebSocket URL
+        fetching so that a 429 from the auth token endpoint triggers the same
+        backoff as a 429 from a normal API call.
+        """
+        cfg = self._config
+        self._rate_limit_hits += 1
+        backoff = min(
+            cfg.rate_limit_cooldown,
+            timedelta(minutes=5) * (2 ** (self._rate_limit_hits - 1)),
+        )
+        self.update_interval = backoff
+        _LOGGER.warning(
+            "Rate limited by %s API (hit #%d), backing off to %s: %s",
+            cfg.api_label,
+            self._rate_limit_hits,
+            backoff,
+            err,
+        )
 
     # ── WebSocket auto-reconnect ────────────────────────────────────────
 

--- a/custom_components/gardena_smart_system/const.py
+++ b/custom_components/gardena_smart_system/const.py
@@ -15,7 +15,7 @@ API_TYPE_GARDENA = "gardena"
 API_TYPE_AUTOMOWER = "automower"
 
 # ── Gardena polling intervals ──────────────────────────────────────
-# The Husqvarna Gardena API allows ~3 000 requests/month (~1 every 15 min).
+# The Husqvarna Gardena API allows ~10 000 requests/month (~14/hour, ~1 every 4 min).
 # 30 min keeps us well within budget even without WebSocket.
 SCAN_INTERVAL = timedelta(minutes=30)
 SCAN_INTERVAL_WS_CONNECTED = timedelta(hours=6)

--- a/tests/components/gardena_smart_system/test_base_coordinator_rate_limit.py
+++ b/tests/components/gardena_smart_system/test_base_coordinator_rate_limit.py
@@ -1,0 +1,415 @@
+"""Tests for base_coordinator rate-limit fixes (WS URL caching, connect guard, backoff)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:
+    from pytest_homeassistant_custom_component.common import (
+        MockConfigEntry,  # type: ignore[no-redef]
+    )
+
+from custom_components.gardena_smart_system.const import (
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_LOCATION_ID,
+    DOMAIN,
+)
+
+from .conftest import ENTRY_DATA, make_mock_device
+
+_PATCH_CLIENT = "custom_components.gardena_smart_system.coordinator.GardenaClient"
+_PATCH_AUTH = "custom_components.gardena_smart_system.coordinator.GardenaAuth"
+_PATCH_WS = "custom_components.gardena_smart_system.coordinator.GardenaWebSocket"
+
+
+def _make_mock_devices() -> dict[str, MagicMock]:
+    dev = make_mock_device()
+    return {dev.device_id: dev}
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=ENTRY_DATA,
+        title="My Garden",
+    )
+
+
+def _setup_mocks(mock_devices: dict[str, MagicMock]):
+    """Patch API classes and return (mock_client, mock_auth, mock_ws) context manager."""
+    mock_auth = AsyncMock()
+    mock_auth.is_token_valid = True
+
+    mock_client = AsyncMock()
+    mock_client.async_get_devices = AsyncMock(return_value=mock_devices)
+    mock_client.async_get_websocket_url = AsyncMock(return_value="wss://test")
+
+    mock_ws = AsyncMock()
+    mock_ws.async_connect = AsyncMock()
+    mock_ws.async_disconnect = AsyncMock()
+    mock_ws.last_message_time = 0
+
+    return mock_client, mock_auth, mock_ws
+
+
+class TestWsUrlCaching:
+    """Fix 1: WebSocket URL is cached and reused while token is valid."""
+
+    async def test_ws_url_cached_on_first_connect(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """After first successful WS connect, the URL should be cached."""
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            assert coordinator._cached_ws_url == "wss://test"
+            mock_client.async_get_websocket_url.assert_called_once()
+
+    async def test_ws_url_reused_on_reconnect_with_valid_token(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """On reconnect with valid token, the cached URL is reused (no new API call)."""
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            assert mock_client.async_get_websocket_url.call_count == 1
+
+            # Simulate WS disconnect + reconnect attempt
+            coordinator._ws_connected = False
+            coordinator._ws = None
+            await coordinator._async_start_websocket(devices)
+
+            # URL should have been reused — no additional fetch
+            assert mock_client.async_get_websocket_url.call_count == 1
+
+    async def test_ws_url_refetched_when_token_expired(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """When the token is no longer valid, a fresh WS URL must be fetched."""
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            assert mock_client.async_get_websocket_url.call_count == 1
+
+            # Expire the token
+            mock_auth.is_token_valid = False
+            coordinator._ws_connected = False
+            coordinator._ws = None
+
+            mock_client.async_get_websocket_url.return_value = "wss://new-url"
+            await coordinator._async_start_websocket(devices)
+
+            assert mock_client.async_get_websocket_url.call_count == 2
+            assert coordinator._cached_ws_url == "wss://new-url"
+
+    async def test_ws_url_cache_invalidated_on_connect_failure(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """If WS connect fails with cached URL, the cache is cleared."""
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            assert coordinator._cached_ws_url == "wss://test"
+
+            # Simulate reconnect with failing connect
+            coordinator._ws_connected = False
+            coordinator._ws = None
+            mock_ws.async_connect = AsyncMock(side_effect=Exception("Connection refused"))
+
+            with patch(_PATCH_WS, return_value=mock_ws):
+                await coordinator._async_start_websocket(devices)
+
+            assert coordinator._cached_ws_url is None
+
+    async def test_ws_url_cache_invalidated_on_ws_error(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """When _on_ws_error is called, the cached URL is cleared."""
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            assert coordinator._cached_ws_url == "wss://test"
+
+            from aiogardenasmart.exceptions import GardenaConnectionError
+
+            coordinator._on_ws_error(GardenaConnectionError("lost"))
+
+            assert coordinator._cached_ws_url is None
+
+
+class TestWsConnectGuard:
+    """Fix 2: asyncio.Lock prevents parallel WS connect attempts."""
+
+    async def test_parallel_connect_attempts_are_blocked(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """When a WS connect is in progress, a second call is skipped."""
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        # Track how many times _async_start_websocket_locked is entered
+        locked_call_count = 0
+        connect_started = asyncio.Event()
+        connect_release = asyncio.Event()
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            coordinator._ws_connected = False
+            coordinator._ws = None
+            coordinator._cached_ws_url = None
+
+            original_locked = coordinator._async_start_websocket_locked
+
+            async def slow_locked(devs):
+                nonlocal locked_call_count
+                locked_call_count += 1
+                connect_started.set()
+                await connect_release.wait()
+                await original_locked(devs)
+
+            coordinator._async_start_websocket_locked = slow_locked
+
+            # Start first connect in background
+            task1 = hass.async_create_task(coordinator._async_start_websocket(devices))
+            await connect_started.wait()
+
+            # Second connect should be skipped (lock is held)
+            await coordinator._async_start_websocket(devices)
+
+            # Only one call entered the locked method
+            assert locked_call_count == 1
+
+            # Release the first connect
+            connect_release.set()
+            await task1
+
+
+class TestRateLimitBackoffFromAuth:
+    """Fix 3: 429 from auth/token endpoint triggers coordinator backoff."""
+
+    async def test_rate_limit_during_ws_url_fetch_triggers_backoff(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """A GardenaRateLimitError during WS URL fetch triggers exponential backoff."""
+        from aiogardenasmart.exceptions import GardenaRateLimitError
+
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            original_interval = coordinator.update_interval
+
+            # Simulate reconnect where WS URL fetch hits rate limit
+            coordinator._ws_connected = False
+            coordinator._ws = None
+            coordinator._cached_ws_url = None
+            mock_client.async_get_websocket_url = AsyncMock(
+                side_effect=GardenaRateLimitError("429 Too Many Requests")
+            )
+
+            await coordinator._async_start_websocket(devices)
+
+            # Backoff should have been applied
+            assert coordinator._rate_limit_hits == 1
+            assert coordinator.update_interval == timedelta(minutes=5)
+
+    async def test_multiple_rate_limits_increase_backoff_exponentially(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Successive rate-limit hits double the backoff interval."""
+        from aiogardenasmart.exceptions import GardenaRateLimitError
+
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            coordinator._ws_connected = False
+            coordinator._ws = None
+            coordinator._cached_ws_url = None
+            mock_client.async_get_websocket_url = AsyncMock(
+                side_effect=GardenaRateLimitError("429")
+            )
+
+            # Hit 1: 5 min
+            await coordinator._async_start_websocket(devices)
+            assert coordinator.update_interval == timedelta(minutes=5)
+
+            # Hit 2: 10 min
+            coordinator._cached_ws_url = None
+            await coordinator._async_start_websocket(devices)
+            assert coordinator.update_interval == timedelta(minutes=10)
+
+            # Hit 3: 20 min
+            coordinator._cached_ws_url = None
+            await coordinator._async_start_websocket(devices)
+            assert coordinator.update_interval == timedelta(minutes=20)
+
+    async def test_backoff_capped_at_cooldown(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Backoff never exceeds RATE_LIMIT_COOLDOWN (1 hour)."""
+        from aiogardenasmart.exceptions import GardenaRateLimitError
+
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            coordinator._ws_connected = False
+            coordinator._ws = None
+            coordinator._cached_ws_url = None
+            mock_client.async_get_websocket_url = AsyncMock(
+                side_effect=GardenaRateLimitError("429")
+            )
+
+            # Simulate many hits
+            for _ in range(10):
+                coordinator._cached_ws_url = None
+                await coordinator._async_start_websocket(devices)
+
+            # Should be capped at 1 hour
+            assert coordinator.update_interval == timedelta(hours=1)
+
+    async def test_rate_limit_resets_on_successful_poll(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """After a successful _async_update_data, rate_limit_hits resets to 0."""
+        from aiogardenasmart.exceptions import GardenaRateLimitError
+
+        devices = _make_mock_devices()
+        mock_client, mock_auth, mock_ws = _setup_mocks(devices)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_AUTH, return_value=mock_auth),
+            patch(_PATCH_WS, return_value=mock_ws),
+        ):
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+
+            # Manually bump rate limit hits
+            coordinator._rate_limit_hits = 5
+            coordinator.update_interval = timedelta(hours=1)
+
+            # Trigger a successful update
+            await coordinator.async_refresh()
+            await hass.async_block_till_done()
+
+            assert coordinator._rate_limit_hits == 0


### PR DESCRIPTION
## Summary

- **WS URL caching**: WebSocket URL is cached and reused across reconnects while the auth token is still valid, eliminating unnecessary `POST /websocket` API calls on every reconnect attempt. Cache is invalidated on token expiry or connection failure.
- **Connect guard**: `asyncio.Lock` prevents parallel WebSocket connect attempts (e.g. watchdog + poll cycle racing), avoiding duplicate API calls.
- **Unified rate-limit backoff**: Extracted `_apply_rate_limit_backoff()` so HTTP 429 errors from token refresh and WS URL fetch trigger the same exponential backoff as normal poll cycles (previously only poll 429s were handled).
- **Corrected rate limit budget**: Updated `const.py` comment and README from ~3,000 to ~10,000 requests/month per the official Husqvarna API documentation.

## Test plan

- [x] 10 new tests in `test_base_coordinator_rate_limit.py` (all passing)
  - WS URL cached on first connect
  - Cached URL reused on reconnect with valid token
  - Fresh URL fetched when token expires
  - Cache invalidated on connect failure
  - Cache invalidated on WS error callback
  - Parallel connect attempts blocked by lock
  - Rate limit during WS URL fetch triggers backoff
  - Multiple rate limits increase backoff exponentially
  - Backoff capped at 1 hour (RATE_LIMIT_COOLDOWN)
  - Rate limit counter resets on successful poll
- [x] All 332 existing Gardena tests still pass (2 unrelated automower import failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)