### PR TITLE
v1.12.10: relax watchdog timeout to 4 h (#20)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,6 +37,7 @@ body:
         `cat /config/custom_components/gardena_smart_system/manifest.json | grep version`
         — pick "Older …" if your version is below 1.12.0; please update before opening a bug report.
       options:
+        - 1.12.10
         - 1.12.9
         - 1.12.8
         - 1.12.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Gardena Smart System integration for Home Assistant.
 
+## [1.12.10] - 2026-04-30
+
+### Changed
+- **Watchdog timeout: 1800 s → 14400 s (4 h) (#20).** v1.12.9 reduced the unnecessary watchdog-driven reconnects on quiet gardens by ~6× but didn't eliminate them: a low-activity garden still saw the watchdog trip every 30 min, force-disconnect a healthy WebSocket, and burn one REST call to fetch a fresh signed URL — ~48 unnecessary fetches/day, ~14 % of the 10 000 monthly REST budget. `_last_message_time` only advances on application-level Gardena messages; aiohttp's PING/PONG keeps the TCP connection alive but is handled internally and doesn't surface as a message, so the timestamp doesn't update on a quiet garden even though everything is fine. aiohttp's `heartbeat=30` is the real liveness check (TCP-level death detected in ~60 s); the application-level watchdog is a last-resort safety net for edge cases where aiohttp's heartbeat itself misbehaves, and 4 h is plenty for that role. Quiet-garden churn drops from ~48/day to ~6/day (~1.7 % of the monthly budget); chatty gardens are unaffected.
+
 ## [1.12.9] - 2026-04-29
 
 ### Fixed

--- a/custom_components/gardena_smart_system/const.py
+++ b/custom_components/gardena_smart_system/const.py
@@ -46,20 +46,27 @@ COMMAND_BURST_CAPACITY = 10
 # a SECOND-LEVEL safety net for "TCP alive but app silent" — i.e. cases
 # where the Gardena server has logically forgotten about us.
 #
-# Previously set to 300 s under the assumption that the API sends app-level
-# `WEBSOCKET_PING` messages every ~2 min. That assumption holds for chatty
-# accounts but fails for users whose devices stay quiet (no state changes,
-# no app-level pings) — see issue #18: a perfectly healthy WS gets killed
-# every 6 min, and the immediate reconnect frequently triggers HTTP 410 on
-# the new signed URL because the server hasn't released the prior session.
-# That single-handedly burned ~240 reconnects/day = ~70 % of the monthly
-# REST budget on healthy connections.
+# History:
+#   300 s → killed healthy WS every 6 min on quiet gardens (issue #18,
+#           ~240 reconnects/day, ~70 % of monthly REST budget burned).
+#   1800 s → reduced to ~48 reconnects/day, but quiet gardens still saw
+#            the watchdog trip on schedule (issue #20).
+#   14400 s (current) → see below.
 #
-# 30 min is well past any realistic app-level idle window (Husqvarna's
-# product behaviour for a low-activity garden), keeps the safety net for
-# truly stuck WS sessions, and aligns with the WS-connected hourly health-
-# check poll which catches "WS dead but TCP alive" on the next REST tick.
-WS_WATCHDOG_TIMEOUT_SECONDS = 1800
+# `_last_message_time` only advances on application-level messages from the
+# Gardena server. aiohttp's PING/PONG is handled internally and does NOT
+# surface as a message, so on a low-activity garden (no state changes, no
+# server-side `WEBSOCKET_PING`) the timestamp doesn't update at all even
+# though the connection is healthy. There is no documented Husqvarna SLA
+# for `WEBSOCKET_PING` cadence, and field reports show idle windows well
+# past 30 min.
+#
+# 4 h is a deliberately conservative second-level safety net: it survives
+# any plausible quiet-garden idle period while still catching the rare
+# edge case where aiohttp's own heartbeat machinery misbehaves (library
+# bug, broken proxy, etc.) before the WS-connected hourly REST health-
+# check would notice via stale data.
+WS_WATCHDOG_TIMEOUT_SECONDS = 14400
 WS_WATCHDOG_CHECK_INTERVAL = timedelta(seconds=60)
 
 # WebSocket handshake kill-switch: after this many consecutive 4xx handshake

--- a/custom_components/gardena_smart_system/manifest.json
+++ b/custom_components/gardena_smart_system/manifest.json
@@ -12,5 +12,5 @@
   "quality_scale": "platinum",
   "requirements": ["aiogardenasmart==0.1.9"],
   "single_config_entry": false,
-  "version": "1.12.9"
+  "version": "1.12.10"
 }

--- a/tests/components/gardena_smart_system/test_coordinator.py
+++ b/tests/components/gardena_smart_system/test_coordinator.py
@@ -843,7 +843,7 @@ class TestWebSocketWatchdog:
         coordinator._ws = ws
         coordinator._ws_connected = True
 
-        # silence=1s < WS_WATCHDOG_TIMEOUT_SECONDS(1800)
+        # silence=1s < WS_WATCHDOG_TIMEOUT_SECONDS(14400)
         _BASE = "custom_components.gardena_smart_system.base_coordinator.time"
         with patch(_BASE + ".monotonic", return_value=1000.0):
             ws.last_message_time = 999.0
@@ -863,10 +863,10 @@ class TestWebSocketWatchdog:
 
         # Patch time.monotonic in the module under test so the test is not
         # affected by freezegun or other time mocking in the HA test harness.
-        # silence=2400s > WS_WATCHDOG_TIMEOUT_SECONDS(1800)
+        # silence=18000s > WS_WATCHDOG_TIMEOUT_SECONDS(14400)
         _BASE = "custom_components.gardena_smart_system.base_coordinator.time"
         with (
-            patch(_BASE + ".monotonic", return_value=3000.0),
+            patch(_BASE + ".monotonic", return_value=18600.0),
             patch.object(coordinator, "async_request_refresh", new_callable=AsyncMock),
         ):
             ws.last_message_time = 600.0
@@ -898,9 +898,10 @@ class TestWebSocketWatchdog:
         coordinator._ws = ws
         coordinator._ws_connected = True
 
+        # silence=18000s > WS_WATCHDOG_TIMEOUT_SECONDS(14400)
         _BASE = "custom_components.gardena_smart_system.base_coordinator.time"
         with (
-            patch(_BASE + ".monotonic", return_value=3000.0),
+            patch(_BASE + ".monotonic", return_value=18600.0),
             patch.object(
                 coordinator, "async_request_refresh", new_callable=AsyncMock
             ) as mock_refresh,


### PR DESCRIPTION
## Summary

Closes #20.

After v1.12.9, on a quiet garden the WebSocket watchdog still trips every 30 min, force-disconnects a healthy WS, and burns one REST call to fetch a fresh signed URL — ~48 unnecessary fetches/day, ~14 % of the 10 k monthly budget.

Root cause: `_last_message_time` only advances on application-level Gardena messages. aiohttp's `heartbeat=30` PING/PONG keeps the TCP connection alive but is handled internally and doesn't surface as a message, so the timestamp doesn't update on a low-activity garden even though the connection is fine.

Fix: `WS_WATCHDOG_TIMEOUT_SECONDS` 1800 → 14400 (30 min → 4 h). aiohttp's `heartbeat=30` is the real liveness check (TCP-level death detected in ~60 s); the application-level watchdog is a last-resort safety net for the edge case where aiohttp's heartbeat itself misbehaves, and 4 h is plenty for that role.

Expected impact:
- Quiet gardens: ~48 unnecessary fetches/day → ~6/day (~14 % → ~1.7 % of monthly budget).
- Chatty gardens: no change (watchdog never trips either way).
- Genuinely stuck WS sessions where aiohttp's heartbeat is also broken: detected in 4 h instead of 30 min — acceptable trade-off for how rare this should be.

## Test plan

- [x] Two existing watchdog tests bumped from silence=2400s/3000s to silence=18000s (cross the new 14400 s threshold).
- [x] Full integration test suite: 616 passed in 9.89s.
- [x] `ruff check` + `ruff format --check`: clean.
- [x] `mypy`: clean.
- [x] `manifest.json` version bumped to 1.12.10.
- [x] `CHANGELOG.md` entry added.
- [x] `bug_report.yml` integration_version dropdown: 1.12.10 prepended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)