### PR TITLE
v1.12.13: poll-after-timeout recovery + opt-in auto-retry (#22)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,6 +37,7 @@ body:
         `cat /config/custom_components/gardena_smart_system/manifest.json | grep version`
         — pick "Older …" if your version is below 1.12.0; please update before opening a bug report.
       options:
+        - 1.12.13
         - 1.12.12
         - 1.12.11
         - 1.12.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Gardena Smart System integration for Home Assistant.
 
+## [1.12.13] - 2026-05-05
+
+### Added
+- **Poll-after-timeout recovery for command requests (#22).** When a command (lawn_mower start/dock/pause, valve open/close, power-socket on/off) hits a client-side timeout or a 502/503/504 from the upstream gateway, the integration now waits up to 10 s for the WebSocket to push the expected activity (`OK_CUTTING`, `MANUAL_WATERING`, `TIME_LIMITED_ON`, etc.). If the device confirms the target state in that window, the error is suppressed — the command actually landed server-side, only the HTTP response was lost. Polling reads the in-memory coordinator only, so no extra REST calls are made and the API budget is unaffected. v1.12.12 made the error message clearer; this release closes the gap for users on schedulers that don't wrap commands in a state check.
+- **Opt-in auto-retry for command timeouts (#22).** New options-flow toggle `auto_retry_on_timeout` (default off). When enabled, after the 10 s poll window passes without the device reaching the target state, the command is sent exactly once more before raising `command_timeout`. Default-off is deliberate: a 504 can race a successful server-side write, and silently retrying `start_mowing` would risk a double-start. Users on the HACS Scheduler component or similar fire-and-forget setups that prefer "double-fire over no-fire" can opt in via the integration's options.
+
 ## [1.12.12] - 2026-05-02
 
 ### Changed

--- a/custom_components/gardena_smart_system/automower_entity.py
+++ b/custom_components/gardena_smart_system/automower_entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -20,9 +21,20 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from aioautomower import AutomowerDevice
 
 from .automower_coordinator import AutomowerCoordinator
-from .const import DOMAIN
+from .const import (
+    COMMAND_POLL_AFTER_TIMEOUT_SECONDS,
+    COMMAND_POLL_INTERVAL_SECONDS,
+    DEFAULT_AUTO_RETRY_ON_TIMEOUT,
+    DOMAIN,
+    OPT_AUTO_RETRY_ON_TIMEOUT,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# HTTP statuses where the gateway timed out / was unavailable. The same
+# uncertainty as a client-side timeout applies — the request may have reached
+# the device anyway.
+_GATEWAY_TIMEOUT_STATUSES = frozenset({502, 503, 504})
 
 
 class AutomowerEntity(CoordinatorEntity[AutomowerCoordinator]):
@@ -90,12 +102,15 @@ class AutomowerEntity(CoordinatorEntity[AutomowerCoordinator]):
         self,
         method: Callable[..., Awaitable[Any]],
         *args: Any,
+        expected_state_check: Callable[[], bool] | None = None,
         **kwargs: Any,
     ) -> None:
         """Run an Automower API command through throttle, budget, and exception mapping.
 
         Mirrors ``GardenaEntity._async_execute_command`` but with
-        Automower-specific exception types. See that method for the rationale.
+        Automower-specific exception types. See that method for the rationale,
+        including the issue #22 poll-after-timeout / opt-in retry behaviour
+        triggered by ``expected_state_check``.
         """
         self.coordinator.check_command_throttle()
         self.coordinator.api_budget.increment()
@@ -108,23 +123,132 @@ class AutomowerEntity(CoordinatorEntity[AutomowerCoordinator]):
                 translation_placeholders={"error": str(err)},
             ) from err
         except AutomowerRequestError as err:
-            translation_key = (
-                "command_timeout" if err.status in (502, 503, 504) else "command_failed"
-            )
+            if err.status in _GATEWAY_TIMEOUT_STATUSES:
+                await self._async_handle_timeout(
+                    err,
+                    method,
+                    args,
+                    kwargs,
+                    expected_state_check=expected_state_check,
+                )
+                return
             raise HomeAssistantError(
                 translation_domain="gardena_smart_system",
-                translation_key=translation_key,
+                translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
         except AutomowerConnectionError as err:
-            raise HomeAssistantError(
-                translation_domain="gardena_smart_system",
-                translation_key="command_timeout",
-                translation_placeholders={"error": str(err)},
-            ) from err
+            await self._async_handle_timeout(
+                err,
+                method,
+                args,
+                kwargs,
+                expected_state_check=expected_state_check,
+            )
+            return
         except AutomowerException as err:
             raise HomeAssistantError(
                 translation_domain="gardena_smart_system",
                 translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
+
+    async def _async_handle_timeout(
+        self,
+        err: AutomowerException,
+        method: Callable[..., Awaitable[Any]],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        *,
+        expected_state_check: Callable[[], bool] | None,
+    ) -> None:
+        """Decide whether an apparent client-side timeout actually failed.
+
+        See ``GardenaEntity._async_handle_timeout`` for the full rationale.
+        """
+        if expected_state_check is not None and await self._async_wait_for_expected_state(
+            expected_state_check
+        ):
+            _LOGGER.info(
+                "%s: command timed out client-side but device reached the expected"
+                " state via WebSocket push — treating as success (%s)",
+                self._device_name,
+                err,
+            )
+            return
+
+        if self._auto_retry_enabled():
+            _LOGGER.info(
+                "%s: command timed out and target state not yet observed,"
+                " auto-retry is enabled — sending command once more",
+                self._device_name,
+            )
+            try:
+                self.coordinator.check_command_throttle()
+                self.coordinator.api_budget.increment()
+                await method(*args, **kwargs)
+            except AutomowerAuthenticationError as retry_err:
+                raise ConfigEntryAuthFailed(
+                    translation_domain="gardena_smart_system",
+                    translation_key="command_failed",
+                    translation_placeholders={"error": str(retry_err)},
+                ) from retry_err
+            except AutomowerException as retry_err:
+                if (
+                    isinstance(retry_err, AutomowerRequestError)
+                    and (retry_err.status in _GATEWAY_TIMEOUT_STATUSES)
+                ) or isinstance(retry_err, AutomowerConnectionError):
+                    translation_key = "command_timeout"
+                else:
+                    translation_key = "command_failed"
+                raise HomeAssistantError(
+                    translation_domain="gardena_smart_system",
+                    translation_key=translation_key,
+                    translation_placeholders={"error": str(retry_err)},
+                ) from retry_err
+            else:
+                if expected_state_check is not None and await self._async_wait_for_expected_state(
+                    expected_state_check
+                ):
+                    _LOGGER.info(
+                        "%s: command succeeded on retry, device reached expected state",
+                        self._device_name,
+                    )
+                    return
+                raise HomeAssistantError(
+                    translation_domain="gardena_smart_system",
+                    translation_key="command_timeout",
+                    translation_placeholders={"error": str(err)},
+                )
+
+        raise HomeAssistantError(
+            translation_domain="gardena_smart_system",
+            translation_key="command_timeout",
+            translation_placeholders={"error": str(err)},
+        ) from err
+
+    async def _async_wait_for_expected_state(
+        self,
+        expected_state_check: Callable[[], bool],
+    ) -> bool:
+        """Poll the coordinator-cached state until the target is observed.
+
+        Reads memory only — the WebSocket push from the Husqvarna cloud is
+        what actually advances the state.
+        """
+        if expected_state_check():
+            return True
+        deadline = asyncio.get_running_loop().time() + COMMAND_POLL_AFTER_TIMEOUT_SECONDS
+        while asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(COMMAND_POLL_INTERVAL_SECONDS)
+            if expected_state_check():
+                return True
+        return False
+
+    def _auto_retry_enabled(self) -> bool:
+        """Return whether the user opted into auto-retry on command timeouts."""
+        return bool(
+            self.coordinator.config_entry.options.get(
+                OPT_AUTO_RETRY_ON_TIMEOUT, DEFAULT_AUTO_RETRY_ON_TIMEOUT
+            )
+        )

--- a/custom_components/gardena_smart_system/automower_lawn_mower.py
+++ b/custom_components/gardena_smart_system/automower_lawn_mower.py
@@ -39,6 +39,14 @@ _ACTIVITY_MAP: dict[str, LawnMowerActivity] = {
     MowerActivity.STOPPED_IN_GARDEN: LawnMowerActivity.ERROR,
 }
 
+# Expected mower activities/states per command, used by the issue #22 poll-
+# after-timeout recovery. Listed liberally — any of these proves the command
+# landed.
+_MOWING_ACTIVITIES = frozenset({MowerActivity.MOWING, MowerActivity.LEAVING})
+_DOCKED_ACTIVITIES = frozenset(
+    {MowerActivity.CHARGING, MowerActivity.PARKED_IN_CS, MowerActivity.GOING_HOME}
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -120,11 +128,11 @@ class AutomowerLawnMowerEntity(AutomowerEntity, LawnMowerEntity):
 
     async def async_start_mowing(self) -> None:
         """Start mowing (resume schedule)."""
-        await self._async_send_command("start")
+        await self._async_send_command("start", expected="mowing")
 
     async def async_dock(self) -> None:
         """Send the mower back to dock until next schedule."""
-        await self._async_send_command("park_until_next_schedule")
+        await self._async_send_command("park_until_next_schedule", expected="docked")
 
     async def async_pause(self) -> None:
         """Pause the mower."""
@@ -132,13 +140,35 @@ class AutomowerLawnMowerEntity(AutomowerEntity, LawnMowerEntity):
 
     async def async_park_until_further_notice(self) -> None:
         """Park the mower indefinitely until manually resumed."""
-        await self._async_send_command("park_until_further_notice")
+        await self._async_send_command("park_until_further_notice", expected="docked")
 
     async def async_resume_schedule(self) -> None:
         """Resume the mower's automatic schedule."""
-        await self._async_send_command("resume_schedule")
+        await self._async_send_command("resume_schedule", expected="mowing")
 
-    async def _async_send_command(self, command: str, **kwargs: Any) -> None:
+    def _make_expected_state_check(self, expected: str | None) -> Callable[[], bool] | None:
+        """Build a coordinator-state probe for issue #22 timeout recovery."""
+        if expected == "mowing":
+            target = _MOWING_ACTIVITIES
+        elif expected == "docked":
+            target = _DOCKED_ACTIVITIES
+        else:
+            return None
+
+        mower_id = self._mower_id
+
+        def _check() -> bool:
+            data = self.coordinator.data or {}
+            device = data.get(mower_id)
+            if device is None or device.mower is None:
+                return False
+            return device.mower.activity in target
+
+        return _check
+
+    async def _async_send_command(
+        self, command: str, *, expected: str | None = None, **kwargs: Any
+    ) -> None:
         """Send a command to the Automower API."""
         device = self._device
         if device is None:
@@ -149,4 +179,9 @@ class AutomowerLawnMowerEntity(AutomowerEntity, LawnMowerEntity):
         method: Callable[..., Awaitable[Any]] = getattr(
             self.coordinator.client, self._COMMAND_METHODS[command]
         )
-        await self._async_execute_command(method, device.mower_id, **kwargs)
+        await self._async_execute_command(
+            method,
+            device.mower_id,
+            expected_state_check=self._make_expected_state_check(expected),
+            **kwargs,
+        )

--- a/custom_components/gardena_smart_system/config_flow.py
+++ b/custom_components/gardena_smart_system/config_flow.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     CONF_LOCATION_ID,
+    DEFAULT_AUTO_RETRY_ON_TIMEOUT,
     DEFAULT_MQTT_TOPIC_PREFIX,
     DEFAULT_POLL_INTERVAL_AUTOMOWER,
     DEFAULT_POLL_INTERVAL_GARDENA,
@@ -52,6 +53,7 @@ from .const import (
     DOMAIN,
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
+    OPT_AUTO_RETRY_ON_TIMEOUT,
     OPT_DEFAULT_SOCKET_MINUTES,
     OPT_DEFAULT_WATERING_MINUTES,
     OPT_MQTT_ENABLE,
@@ -579,12 +581,18 @@ class GardenaOptionsFlowHandler(OptionsFlow):
         schema_dict[vol.Required(OPT_MQTT_PUBLISH_STATES)] = BooleanSelector()
         schema_dict[vol.Required(OPT_MQTT_SUBSCRIBE_COMMANDS)] = BooleanSelector()
 
+        current_auto_retry = self.config_entry.options.get(
+            OPT_AUTO_RETRY_ON_TIMEOUT, DEFAULT_AUTO_RETRY_ON_TIMEOUT
+        )
+        schema_dict[vol.Required(OPT_AUTO_RETRY_ON_TIMEOUT)] = BooleanSelector()
+
         suggested_values: dict[str, Any] = {
             OPT_POLL_INTERVAL_MINUTES: current_poll,
             OPT_MQTT_ENABLE: current_mqtt,
             OPT_MQTT_TOPIC_PREFIX: current_mqtt_prefix,
             OPT_MQTT_PUBLISH_STATES: current_mqtt_publish,
             OPT_MQTT_SUBSCRIBE_COMMANDS: current_mqtt_commands,
+            OPT_AUTO_RETRY_ON_TIMEOUT: current_auto_retry,
         }
         if not is_automower:
             suggested_values[OPT_DEFAULT_WATERING_MINUTES] = current_watering

--- a/custom_components/gardena_smart_system/const.py
+++ b/custom_components/gardena_smart_system/const.py
@@ -129,8 +129,21 @@ API_BUDGET_STOP_PERCENT = 5.0
 OPT_DEFAULT_WATERING_MINUTES = "default_watering_minutes"
 OPT_DEFAULT_SOCKET_MINUTES = "default_socket_minutes"
 OPT_POLL_INTERVAL_MINUTES = "poll_interval_minutes"
+OPT_AUTO_RETRY_ON_TIMEOUT = "auto_retry_on_timeout"
 DEFAULT_WATERING_MINUTES = 60
 DEFAULT_SOCKET_MINUTES = 60
+DEFAULT_AUTO_RETRY_ON_TIMEOUT = False
+
+# ── Command-timeout recovery ─────────────────────────────────────
+# When a command fails with a client-side timeout / 502 / 503 / 504, the
+# request may or may not have been processed server-side. The Gardena API
+# pushes a state update via WebSocket the moment the device acknowledges the
+# command, so the integration waits up to COMMAND_POLL_AFTER_TIMEOUT_SECONDS
+# (checking the cached coordinator state every COMMAND_POLL_INTERVAL_SECONDS)
+# before deciding the command actually failed. Polling reads the in-memory
+# coordinator only — no extra REST calls are made.
+COMMAND_POLL_AFTER_TIMEOUT_SECONDS = 10.0
+COMMAND_POLL_INTERVAL_SECONDS = 1.0
 
 # ── MQTT bridge options ──────────────────────────────────────────
 OPT_MQTT_ENABLE = "mqtt_enable"

--- a/custom_components/gardena_smart_system/entity.py
+++ b/custom_components/gardena_smart_system/entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -19,10 +20,21 @@ from aiogardenasmart import (
     GardenaRequestError,
 )
 
-from .const import DOMAIN
+from .const import (
+    COMMAND_POLL_AFTER_TIMEOUT_SECONDS,
+    COMMAND_POLL_INTERVAL_SECONDS,
+    DEFAULT_AUTO_RETRY_ON_TIMEOUT,
+    DOMAIN,
+    OPT_AUTO_RETRY_ON_TIMEOUT,
+)
 from .coordinator import GardenaCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# HTTP statuses where the gateway timed out / was unavailable. The same
+# uncertainty as a client-side timeout applies — the request may have reached
+# the device anyway.
+_GATEWAY_TIMEOUT_STATUSES = frozenset({502, 503, 504})
 
 
 def resolve_zone_placeholder(device: Device, service_id: str) -> str:
@@ -112,6 +124,7 @@ class GardenaEntity(CoordinatorEntity[GardenaCoordinator]):
         self,
         method: Callable[..., Awaitable[Any]],
         *args: Any,
+        expected_state_check: Callable[[], bool] | None = None,
         **kwargs: Any,
     ) -> None:
         """Run an API command through throttle, budget, and exception mapping.
@@ -122,6 +135,18 @@ class GardenaEntity(CoordinatorEntity[GardenaCoordinator]):
         v1.10.4 fix), auth failures trigger reauth, transient upstream timeouts
         surface a "may have happened, check state" message, and all other API
         errors surface as translated HomeAssistantError.
+
+        ``expected_state_check`` (issue #22): a zero-arg callable that returns
+        ``True`` once the coordinator's cached state reflects the command's
+        target. When a client-side timeout / 502 / 503 / 504 hits — situations
+        where the request may still have been processed server-side — the
+        method polls this lambda for up to COMMAND_POLL_AFTER_TIMEOUT_SECONDS
+        before re-raising. The coordinator is updated by the WebSocket push;
+        polling here reads memory only, no extra REST calls.
+
+        If ``auto_retry_on_timeout`` is enabled in the config entry options
+        and polling yields no state change, the command is sent exactly once
+        more before giving up.
         """
         self.coordinator.check_command_throttle()
         self.coordinator.api_budget.increment()
@@ -134,31 +159,145 @@ class GardenaEntity(CoordinatorEntity[GardenaCoordinator]):
                 translation_placeholders={"error": str(err)},
             ) from err
         except GardenaRequestError as err:
-            # 502/503/504 from the upstream gateway: the request reached the
-            # Gardena edge but the backend timed out or was unavailable. The
-            # command may or may not have been processed — surface that
-            # uncertainty so users check device state instead of blindly
-            # retrying.
-            translation_key = (
-                "command_timeout" if err.status in (502, 503, 504) else "command_failed"
-            )
+            if err.status in _GATEWAY_TIMEOUT_STATUSES:
+                await self._async_handle_timeout(
+                    err,
+                    method,
+                    args,
+                    kwargs,
+                    expected_state_check=expected_state_check,
+                )
+                return
             raise HomeAssistantError(
                 translation_domain="gardena_smart_system",
-                translation_key=translation_key,
+                translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
         except GardenaConnectionError as err:
-            # Network-level failure (DNS, connection refused, client timeout).
-            # Same uncertainty as 504 — a client-side timeout can still race a
-            # successful server-side write.
-            raise HomeAssistantError(
-                translation_domain="gardena_smart_system",
-                translation_key="command_timeout",
-                translation_placeholders={"error": str(err)},
-            ) from err
+            await self._async_handle_timeout(
+                err,
+                method,
+                args,
+                kwargs,
+                expected_state_check=expected_state_check,
+            )
+            return
         except GardenaException as err:
             raise HomeAssistantError(
                 translation_domain="gardena_smart_system",
                 translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
+
+    async def _async_handle_timeout(
+        self,
+        err: GardenaException,
+        method: Callable[..., Awaitable[Any]],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        *,
+        expected_state_check: Callable[[], bool] | None,
+    ) -> None:
+        """Decide whether an apparent client-side timeout actually failed.
+
+        Implements the issue #22 recovery path: poll the coordinator for the
+        expected target state, then optionally retry once when configured.
+        Always raises ``HomeAssistantError`` with the ``command_timeout``
+        translation key when the device cannot be confirmed in the target
+        state.
+        """
+        if expected_state_check is not None and await self._async_wait_for_expected_state(
+            expected_state_check
+        ):
+            _LOGGER.info(
+                "%s: command timed out client-side but device reached the expected"
+                " state via WebSocket push — treating as success (%s)",
+                self._device_name,
+                err,
+            )
+            return
+
+        if self._auto_retry_enabled():
+            _LOGGER.info(
+                "%s: command timed out and target state not yet observed,"
+                " auto-retry is enabled — sending command once more",
+                self._device_name,
+            )
+            try:
+                self.coordinator.check_command_throttle()
+                self.coordinator.api_budget.increment()
+                await method(*args, **kwargs)
+            except GardenaAuthenticationError as retry_err:
+                raise ConfigEntryAuthFailed(
+                    translation_domain="gardena_smart_system",
+                    translation_key="command_failed",
+                    translation_placeholders={"error": str(retry_err)},
+                ) from retry_err
+            except GardenaException as retry_err:
+                # Retry hit a fresh error: surface the most informative key.
+                # 5xx/connection errors keep the timeout messaging; everything
+                # else is a deterministic failure.
+                if (
+                    isinstance(retry_err, GardenaRequestError)
+                    and (retry_err.status in _GATEWAY_TIMEOUT_STATUSES)
+                ) or isinstance(retry_err, GardenaConnectionError):
+                    translation_key = "command_timeout"
+                else:
+                    translation_key = "command_failed"
+                raise HomeAssistantError(
+                    translation_domain="gardena_smart_system",
+                    translation_key=translation_key,
+                    translation_placeholders={"error": str(retry_err)},
+                ) from retry_err
+            else:
+                if expected_state_check is not None and await self._async_wait_for_expected_state(
+                    expected_state_check
+                ):
+                    _LOGGER.info(
+                        "%s: command succeeded on retry, device reached expected state",
+                        self._device_name,
+                    )
+                    return
+                # Retry returned cleanly but we still cannot confirm the
+                # device state. Mirror the original timeout so the user knows
+                # to check.
+                raise HomeAssistantError(
+                    translation_domain="gardena_smart_system",
+                    translation_key="command_timeout",
+                    translation_placeholders={"error": str(err)},
+                )
+
+        raise HomeAssistantError(
+            translation_domain="gardena_smart_system",
+            translation_key="command_timeout",
+            translation_placeholders={"error": str(err)},
+        ) from err
+
+    async def _async_wait_for_expected_state(
+        self,
+        expected_state_check: Callable[[], bool],
+    ) -> bool:
+        """Poll the coordinator-cached state until the target is observed.
+
+        Reads memory only — the WebSocket push from the Gardena cloud is what
+        actually advances the state. Returns ``True`` if the lambda returns
+        truthy within COMMAND_POLL_AFTER_TIMEOUT_SECONDS, ``False`` otherwise.
+        """
+        # Initial check before the first sleep — the WebSocket may already
+        # have pushed the new state by the time the API call returns.
+        if expected_state_check():
+            return True
+        deadline = asyncio.get_running_loop().time() + COMMAND_POLL_AFTER_TIMEOUT_SECONDS
+        while asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(COMMAND_POLL_INTERVAL_SECONDS)
+            if expected_state_check():
+                return True
+        return False
+
+    def _auto_retry_enabled(self) -> bool:
+        """Return whether the user opted into auto-retry on command timeouts."""
+        return bool(
+            self.coordinator.config_entry.options.get(
+                OPT_AUTO_RETRY_ON_TIMEOUT, DEFAULT_AUTO_RETRY_ON_TIMEOUT
+            )
+        )

--- a/custom_components/gardena_smart_system/lawn_mower.py
+++ b/custom_components/gardena_smart_system/lawn_mower.py
@@ -5,6 +5,7 @@ Maps the MOWER service to a HA lawn_mower entity.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import cast
 
 import voluptuous as vol
@@ -46,6 +47,25 @@ _MOWER_ACTIVITY_MAP: dict[str, LawnMowerActivity] = {
     MowerActivity.PAUSED_IN_CS: LawnMowerActivity.PAUSED,
     MowerActivity.STOPPED_IN_GARDEN: LawnMowerActivity.ERROR,
 }
+
+# Expected mower activities per command kind, for the issue #22 poll-after-
+# timeout recovery. Listed liberally — any of these proves the command landed.
+_MOWING_ACTIVITIES = frozenset(
+    {
+        MowerActivity.OK_CUTTING,
+        MowerActivity.OK_CUTTING_TIMER_OVERRIDDEN,
+        MowerActivity.OK_LEAVING,
+        MowerActivity.OK_SEARCHING,
+    }
+)
+_PARKED_ACTIVITIES = frozenset(
+    {
+        MowerActivity.PARKED_PARK_SELECTED,
+        MowerActivity.PARKED_TIMER,
+        MowerActivity.PARKED_AUTOTIMER,
+        MowerActivity.OK_CHARGING,
+    }
+)
 
 
 async def async_setup_entry(
@@ -127,32 +147,57 @@ class GardenaLawnMowerEntity(GardenaEntity, LawnMowerEntity):
 
     async def async_start_mowing(self) -> None:
         """Start mowing without overriding the schedule."""
-        await self._async_send_command("START_DONT_OVERRIDE")
+        await self._async_send_command("START_DONT_OVERRIDE", expected="mowing")
 
     async def async_override_schedule(self, duration: int) -> None:
         """Force mowing for the given number of minutes, overriding the schedule."""
         await self._async_send_command(
             "START_SECONDS_TO_OVERRIDE",
+            expected="mowing",
             seconds=duration * 60,
         )
 
     async def async_dock(self) -> None:
         """Send the mower back to dock."""
-        await self._async_send_command("PARK_UNTIL_NEXT_TASK")
+        await self._async_send_command("PARK_UNTIL_NEXT_TASK", expected="parked")
 
     async def async_pause(self) -> None:
         """Pause the mower and park until further notice."""
-        await self._async_send_command("PARK_UNTIL_FURTHER_NOTICE")
+        await self._async_send_command("PARK_UNTIL_FURTHER_NOTICE", expected="parked")
 
     async def async_park_until_further_notice(self) -> None:
         """Park the mower indefinitely until manually resumed."""
-        await self._async_send_command("PARK_UNTIL_FURTHER_NOTICE")
+        await self._async_send_command("PARK_UNTIL_FURTHER_NOTICE", expected="parked")
 
     async def async_resume_schedule(self) -> None:
         """Resume the mower's automatic mowing schedule."""
-        await self._async_send_command("START_DONT_OVERRIDE")
+        await self._async_send_command("START_DONT_OVERRIDE", expected="mowing")
 
-    async def _async_send_command(self, command: str, **params: int) -> None:
+    def _make_expected_state_check(self, expected: str | None) -> Callable[[], bool] | None:
+        """Build a coordinator-state probe for issue #22 timeout recovery."""
+        if expected is None:
+            return None
+        if expected == "mowing":
+            target = _MOWING_ACTIVITIES
+        elif expected == "parked":
+            target = _PARKED_ACTIVITIES
+        else:  # pragma: no cover — defensive
+            return None
+
+        device_id = self._device_id
+
+        def _check() -> bool:
+            data = self.coordinator.data or {}
+            device = data.get(device_id)
+            if device is None or device.mower is None:
+                return False
+            return device.mower.activity in target
+
+        return _check
+
+    async def _async_send_command(
+        self, command: str, *, expected: str | None = None, **params: int
+    ) -> None:
         """Send a command to the mower service."""
         device = self._device
         if device is None or device.mower is None:
@@ -165,5 +210,6 @@ class GardenaLawnMowerEntity(GardenaEntity, LawnMowerEntity):
             service_id=device.mower.service_id,
             control_type=ControlType.MOWER,
             command=command,
+            expected_state_check=self._make_expected_state_check(expected),
             **params,
         )

--- a/custom_components/gardena_smart_system/manifest.json
+++ b/custom_components/gardena_smart_system/manifest.json
@@ -12,5 +12,5 @@
   "quality_scale": "platinum",
   "requirements": ["aiogardenasmart==0.1.9"],
   "single_config_entry": false,
-  "version": "1.12.12"
+  "version": "1.12.13"
 }

--- a/custom_components/gardena_smart_system/strings.json
+++ b/custom_components/gardena_smart_system/strings.json
@@ -76,7 +76,8 @@
           "mqtt_enable": "Enable MQTT bridge",
           "mqtt_topic_prefix": "MQTT topic prefix",
           "mqtt_publish_states": "Publish device states to MQTT",
-          "mqtt_subscribe_commands": "Accept commands via MQTT"
+          "mqtt_subscribe_commands": "Accept commands via MQTT",
+          "auto_retry_on_timeout": "Auto-retry commands on timeout"
         },
         "data_description": {
           "default_watering_minutes": "Duration in minutes when opening a valve without specifying a duration (1-1440).",
@@ -85,7 +86,8 @@
           "mqtt_enable": "Mirror device states to a local MQTT broker and optionally accept commands. Requires the MQTT integration to be configured.",
           "mqtt_topic_prefix": "Base topic for all MQTT messages (e.g. 'gardena' → gardena/{device_id}/state).",
           "mqtt_publish_states": "Publish full device state as JSON on every update (WebSocket push or poll).",
-          "mqtt_subscribe_commands": "Subscribe to {prefix}/{device_id}/command for inbound commands (start_watering, stop_watering, turn_on, turn_off, park, resume)."
+          "mqtt_subscribe_commands": "Subscribe to {prefix}/{device_id}/command for inbound commands (start_watering, stop_watering, turn_on, turn_off, park, resume).",
+          "auto_retry_on_timeout": "When a command times out and the device does not reach the expected state within 10 s, send the command once more. Off by default — leave off if you would rather see a clear error than risk a duplicate command."
         }
       }
     }

--- a/custom_components/gardena_smart_system/switch.py
+++ b/custom_components/gardena_smart_system/switch.py
@@ -5,6 +5,7 @@ Maps the POWER_SOCKET service to a HA switch entity.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, cast
 
@@ -120,6 +121,30 @@ class GardenaPowerSocketEntity(GardenaEntity, SwitchEntity):
         """Turn the socket off."""
         await self._async_send_command("STOP_UNTIL_NEXT_TASK")
 
+    def _make_expected_state_check(self, command: str) -> Callable[[], bool] | None:
+        """Build a coordinator-state probe for issue #22 timeout recovery."""
+        if command == "START_SECONDS_TO_OVERRIDE":
+            target = (
+                PowerSocketActivity.TIME_LIMITED_ON,
+                PowerSocketActivity.FOREVER_ON,
+                PowerSocketActivity.SCHEDULED_ON,
+            )
+        elif command == "STOP_UNTIL_NEXT_TASK":
+            target = (PowerSocketActivity.OFF,)
+        else:
+            return None
+
+        device_id = self._device_id
+
+        def _check() -> bool:
+            data = self.coordinator.data or {}
+            device = data.get(device_id)
+            if device is None or device.power_socket is None:
+                return False
+            return device.power_socket.activity in target
+
+        return _check
+
     async def _async_send_command(self, command: str, **params: int) -> None:
         """Send a command to the power socket service."""
         device = self._device
@@ -133,6 +158,7 @@ class GardenaPowerSocketEntity(GardenaEntity, SwitchEntity):
             service_id=device.power_socket.service_id,
             control_type=ControlType.POWER_SOCKET,
             command=command,
+            expected_state_check=self._make_expected_state_check(command),
             **params,
         )
         self._apply_optimistic_state(command, params)

--- a/custom_components/gardena_smart_system/switch.py
+++ b/custom_components/gardena_smart_system/switch.py
@@ -124,13 +124,15 @@ class GardenaPowerSocketEntity(GardenaEntity, SwitchEntity):
     def _make_expected_state_check(self, command: str) -> Callable[[], bool] | None:
         """Build a coordinator-state probe for issue #22 timeout recovery."""
         if command == "START_SECONDS_TO_OVERRIDE":
-            target = (
-                PowerSocketActivity.TIME_LIMITED_ON,
-                PowerSocketActivity.FOREVER_ON,
-                PowerSocketActivity.SCHEDULED_ON,
+            target: frozenset[str] = frozenset(
+                {
+                    PowerSocketActivity.TIME_LIMITED_ON,
+                    PowerSocketActivity.FOREVER_ON,
+                    PowerSocketActivity.SCHEDULED_ON,
+                }
             )
         elif command == "STOP_UNTIL_NEXT_TASK":
-            target = (PowerSocketActivity.OFF,)
+            target = frozenset({PowerSocketActivity.OFF})
         else:
             return None
 

--- a/custom_components/gardena_smart_system/translations/de.json
+++ b/custom_components/gardena_smart_system/translations/de.json
@@ -76,7 +76,8 @@
           "mqtt_enable": "MQTT-Bridge aktivieren",
           "mqtt_topic_prefix": "MQTT-Topic-Präfix",
           "mqtt_publish_states": "Gerätezustände per MQTT veröffentlichen",
-          "mqtt_subscribe_commands": "Befehle per MQTT empfangen"
+          "mqtt_subscribe_commands": "Befehle per MQTT empfangen",
+          "auto_retry_on_timeout": "Befehle bei Timeout automatisch wiederholen"
         },
         "data_description": {
           "default_watering_minutes": "Dauer in Minuten beim Öffnen eines Ventils ohne Angabe einer Dauer (1–1440).",
@@ -85,7 +86,8 @@
           "mqtt_enable": "Spiegelt Gerätezustände auf einen lokalen MQTT-Broker und empfängt optional Befehle. Die MQTT-Integration muss konfiguriert sein.",
           "mqtt_topic_prefix": "Basis-Topic für alle MQTT-Nachrichten (z.B. ‘gardena’ → gardena/DEVICE_ID/state).",
           "mqtt_publish_states": "Veröffentlicht den vollständigen Gerätezustand als JSON bei jeder Aktualisierung (WebSocket-Push oder Abfrage).",
-          "mqtt_subscribe_commands": "Abonniert PREFIX/DEVICE_ID/command für eingehende Befehle (start_watering, stop_watering, turn_on, turn_off, park, resume)."
+          "mqtt_subscribe_commands": "Abonniert PREFIX/DEVICE_ID/command für eingehende Befehle (start_watering, stop_watering, turn_on, turn_off, park, resume).",
+          "auto_retry_on_timeout": "Wenn ein Befehl in einen Timeout läuft und das Gerät innerhalb von 10 s nicht den erwarteten Zustand erreicht, wird der Befehl einmalig erneut gesendet. Standardmäßig aus — aktiviere die Option nur, wenn ein doppelter Befehl für dich akzeptabel ist."
         }
       }
     }

--- a/custom_components/gardena_smart_system/translations/en.json
+++ b/custom_components/gardena_smart_system/translations/en.json
@@ -76,7 +76,8 @@
           "mqtt_enable": "Enable MQTT bridge",
           "mqtt_topic_prefix": "MQTT topic prefix",
           "mqtt_publish_states": "Publish device states to MQTT",
-          "mqtt_subscribe_commands": "Accept commands via MQTT"
+          "mqtt_subscribe_commands": "Accept commands via MQTT",
+          "auto_retry_on_timeout": "Auto-retry commands on timeout"
         },
         "data_description": {
           "default_watering_minutes": "Duration in minutes when opening a valve without specifying a duration (1-1440).",
@@ -85,7 +86,8 @@
           "mqtt_enable": "Mirror device states to a local MQTT broker and optionally accept commands. Requires the MQTT integration to be configured.",
           "mqtt_topic_prefix": "Base topic for all MQTT messages (e.g. 'gardena' → gardena/DEVICE_ID/state).",
           "mqtt_publish_states": "Publish full device state as JSON on every update (WebSocket push or poll).",
-          "mqtt_subscribe_commands": "Subscribe to PREFIX/DEVICE_ID/command for inbound commands (start_watering, stop_watering, turn_on, turn_off, park, resume)."
+          "mqtt_subscribe_commands": "Subscribe to PREFIX/DEVICE_ID/command for inbound commands (start_watering, stop_watering, turn_on, turn_off, park, resume).",
+          "auto_retry_on_timeout": "When a command times out and the device does not reach the expected state within 10 s, send the command once more. Off by default — leave off if you would rather see a clear error than risk a duplicate command."
         }
       }
     }

--- a/custom_components/gardena_smart_system/valve.py
+++ b/custom_components/gardena_smart_system/valve.py
@@ -7,6 +7,7 @@ to a HA valve entity.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, cast
 
@@ -164,6 +165,30 @@ class GardenaValveEntity(GardenaEntity, ValveEntity):
                 translation_placeholders={"limit": str(MAX_CONCURRENT_IRRIGATION_VALVES)},
             )
 
+    def _make_expected_state_check(self, command: str) -> Callable[[], bool] | None:
+        """Build a coordinator-state probe for issue #22 timeout recovery."""
+        if command == "START_SECONDS_TO_OVERRIDE":
+            target = (ValveActivity.MANUAL_WATERING, ValveActivity.SCHEDULED_WATERING)
+        elif command == "STOP_UNTIL_NEXT_TASK":
+            target = (ValveActivity.CLOSED,)
+        else:
+            return None
+
+        device_id = self._device_id
+        service_id = self._service_id
+
+        def _check() -> bool:
+            data = self.coordinator.data or {}
+            device = data.get(device_id)
+            if device is None:
+                return False
+            valve = device.valves.get(service_id)
+            if valve is None:
+                return False
+            return valve.activity in target
+
+        return _check
+
     async def _async_send_command(self, command: str, **params: int) -> None:
         """Send a command to this valve."""
         if self._device is None or self._valve is None:
@@ -176,6 +201,7 @@ class GardenaValveEntity(GardenaEntity, ValveEntity):
             service_id=self._service_id,
             control_type=ControlType.VALVE,
             command=command,
+            expected_state_check=self._make_expected_state_check(command),
             **params,
         )
         self._apply_optimistic_state(command, params)

--- a/custom_components/gardena_smart_system/valve.py
+++ b/custom_components/gardena_smart_system/valve.py
@@ -168,9 +168,11 @@ class GardenaValveEntity(GardenaEntity, ValveEntity):
     def _make_expected_state_check(self, command: str) -> Callable[[], bool] | None:
         """Build a coordinator-state probe for issue #22 timeout recovery."""
         if command == "START_SECONDS_TO_OVERRIDE":
-            target = (ValveActivity.MANUAL_WATERING, ValveActivity.SCHEDULED_WATERING)
+            target: frozenset[str] = frozenset(
+                {ValveActivity.MANUAL_WATERING, ValveActivity.SCHEDULED_WATERING}
+            )
         elif command == "STOP_UNTIL_NEXT_TASK":
-            target = (ValveActivity.CLOSED,)
+            target = frozenset({ValveActivity.CLOSED})
         else:
             return None
 

--- a/tests/components/gardena_smart_system/conftest.py
+++ b/tests/components/gardena_smart_system/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -131,6 +131,36 @@ def make_mock_location(
     loc.location_id = location_id
     loc.name = name
     return loc
+
+
+@pytest.fixture(autouse=True)
+def _shrink_command_timeout_poll_window():
+    """Collapse the issue #22 poll-after-timeout window for fast tests.
+
+    Default is a 10 s real-time poll, which would multiply the test suite
+    runtime by every error-path test. Recovery tests that need a non-zero
+    window patch these constants themselves.
+    """
+    with (
+        patch(
+            "custom_components.gardena_smart_system.entity.COMMAND_POLL_AFTER_TIMEOUT_SECONDS",
+            0.0,
+        ),
+        patch(
+            "custom_components.gardena_smart_system.entity.COMMAND_POLL_INTERVAL_SECONDS",
+            0.0,
+        ),
+        patch(
+            "custom_components.gardena_smart_system.automower_entity"
+            ".COMMAND_POLL_AFTER_TIMEOUT_SECONDS",
+            0.0,
+        ),
+        patch(
+            "custom_components.gardena_smart_system.automower_entity.COMMAND_POLL_INTERVAL_SECONDS",
+            0.0,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/gardena_smart_system/test_automower.py
+++ b/tests/components/gardena_smart_system/test_automower.py
@@ -689,7 +689,9 @@ class TestAutomowerLawnMowerCommands:
     async def test_gateway_timeout_uses_command_timeout_translation(
         self, hass: HomeAssistant, automower_config_entry: MockConfigEntry, status: int
     ) -> None:
-        device = make_mock_automower_device()
+        # Start parked so the issue #22 poll-after-timeout recovery cannot
+        # short-circuit by observing the device already in the target state.
+        device = make_mock_automower_device(mower_activity=MowerActivity.PARKED_IN_CS)
         devices = {device.mower_id: device}
 
         async with _setup_automower(hass, automower_config_entry, devices) as mock_client:
@@ -727,7 +729,9 @@ class TestAutomowerLawnMowerCommands:
     async def test_connection_error_uses_command_timeout_translation(
         self, hass: HomeAssistant, automower_config_entry: MockConfigEntry
     ) -> None:
-        device = make_mock_automower_device()
+        # Start parked so the issue #22 poll-after-timeout recovery cannot
+        # short-circuit by observing the device already in the target state.
+        device = make_mock_automower_device(mower_activity=MowerActivity.PARKED_IN_CS)
         devices = {device.mower_id: device}
 
         async with _setup_automower(hass, automower_config_entry, devices) as mock_client:
@@ -3139,6 +3143,7 @@ class TestAutomowerMiscCoverage:
                 "mqtt_topic_prefix": "gardena",
                 "mqtt_publish_states": True,
                 "mqtt_subscribe_commands": True,
+                "auto_retry_on_timeout": False,
             },
         )
         assert result["type"] == "create_entry"

--- a/tests/components/gardena_smart_system/test_automower_timeout_recovery.py
+++ b/tests/components/gardena_smart_system/test_automower_timeout_recovery.py
@@ -1,0 +1,168 @@
+"""Tests for the Automower path of issue #22 timeout recovery."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aioautomower.const import MowerActivity
+from aioautomower.exceptions import AutomowerConnectionError
+from aioautomower.models import AutomowerDevice
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:
+    from pytest_homeassistant_custom_component.common import (
+        MockConfigEntry,  # type: ignore[no-redef]
+    )
+
+from custom_components.gardena_smart_system.const import (
+    DOMAIN,
+    OPT_AUTO_RETRY_ON_TIMEOUT,
+)
+
+from .test_automower import AUTOMOWER_ENTRY_DATA, make_mock_automower_device
+
+_PATCH_AM_CLIENT = "custom_components.gardena_smart_system.automower_coordinator.AutomowerClient"
+_PATCH_AM_AUTH = "custom_components.gardena_smart_system.automower_coordinator.GardenaAuth"
+_PATCH_AM_WS = "custom_components.gardena_smart_system.automower_coordinator.AutomowerWebSocket"
+
+
+@asynccontextmanager
+async def _setup_automower(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    devices: dict[str, AutomowerDevice],
+) -> AsyncGenerator[AsyncMock]:
+    """Set up the integration with Automower devices and yield the mock client."""
+    with (
+        patch(_PATCH_AM_CLIENT) as mock_client_cls,
+        patch(_PATCH_AM_AUTH, return_value=AsyncMock()),
+        patch(_PATCH_AM_WS) as mock_ws_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.async_get_mowers = AsyncMock(return_value=devices)
+        mock_client.async_start = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        mock_ws = AsyncMock()
+        mock_ws.async_connect = AsyncMock()
+        mock_ws.async_disconnect = AsyncMock()
+        mock_ws_cls.return_value = mock_ws
+
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        yield mock_client
+
+
+@pytest.fixture
+def automower_config_entry() -> MockConfigEntry:
+    """Return a MockConfigEntry for the Automower integration."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=AUTOMOWER_ENTRY_DATA,
+        title="Automower",
+        version=2,
+    )
+
+
+def _push_mowing_state(coordinator, device: AutomowerDevice) -> None:
+    """Mutate the coordinator-cached AutomowerDevice into the MOWING activity."""
+    new_mower = dataclasses.replace(device.mower, activity=MowerActivity.MOWING)
+    new_device = dataclasses.replace(device, mower=new_mower)
+    coordinator.async_set_updated_data({device.mower_id: new_device})
+
+
+class TestAutomowerTimeoutRecovery:
+    """Mirror of the Gardena recovery tests for the Automower path."""
+
+    async def test_recovery_when_state_reaches_target(
+        self, hass: HomeAssistant, automower_config_entry: MockConfigEntry
+    ) -> None:
+        """Connection error but device reached MOWING — error is suppressed."""
+        device = make_mock_automower_device(mower_activity=MowerActivity.PARKED_IN_CS)
+        devices = {device.mower_id: device}
+
+        async with _setup_automower(hass, automower_config_entry, devices) as mock_client:
+            coordinator = automower_config_entry.runtime_data
+
+            def _side_effect(*_args: Any, **_kwargs: Any) -> None:
+                _push_mowing_state(coordinator, device)
+                raise AutomowerConnectionError("Timeout")
+
+            mock_client.async_start.side_effect = _side_effect
+
+            await hass.services.async_call(
+                "lawn_mower",
+                "start_mowing",
+                {"entity_id": "lawn_mower.test_mower_mower"},
+                blocking=True,
+            )
+
+            assert mock_client.async_start.call_count == 1
+
+    async def test_no_recovery_no_retry_raises_command_timeout(
+        self, hass: HomeAssistant, automower_config_entry: MockConfigEntry
+    ) -> None:
+        """No state change + retry disabled → command_timeout, no second call."""
+        device = make_mock_automower_device(mower_activity=MowerActivity.PARKED_IN_CS)
+        devices = {device.mower_id: device}
+
+        async with _setup_automower(hass, automower_config_entry, devices) as mock_client:
+            mock_client.async_start.side_effect = AutomowerConnectionError("Timeout")
+
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await hass.services.async_call(
+                    "lawn_mower",
+                    "start_mowing",
+                    {"entity_id": "lawn_mower.test_mower_mower"},
+                    blocking=True,
+                )
+
+            assert exc_info.value.translation_key == "command_timeout"
+            assert mock_client.async_start.call_count == 1
+
+    async def test_retry_succeeds_when_second_call_lands(
+        self, hass: HomeAssistant, automower_config_entry: MockConfigEntry
+    ) -> None:
+        """First call times out, second call returns cleanly and state arrives."""
+        device = make_mock_automower_device(mower_activity=MowerActivity.PARKED_IN_CS)
+        devices = {device.mower_id: device}
+
+        async with _setup_automower(hass, automower_config_entry, devices) as mock_client:
+            hass.config_entries.async_update_entry(
+                automower_config_entry,
+                options={
+                    **automower_config_entry.options,
+                    OPT_AUTO_RETRY_ON_TIMEOUT: True,
+                },
+            )
+            await hass.async_block_till_done()
+
+            coordinator = automower_config_entry.runtime_data
+            calls: list[int] = []
+
+            def _side_effect(*_args: Any, **_kwargs: Any) -> None:
+                calls.append(1)
+                if len(calls) == 1:
+                    raise AutomowerConnectionError("Timeout")
+                _push_mowing_state(coordinator, device)
+
+            mock_client.async_start.side_effect = _side_effect
+
+            await hass.services.async_call(
+                "lawn_mower",
+                "start_mowing",
+                {"entity_id": "lawn_mower.test_mower_mower"},
+                blocking=True,
+            )
+
+            assert mock_client.async_start.call_count == 2

--- a/tests/components/gardena_smart_system/test_config_flow.py
+++ b/tests/components/gardena_smart_system/test_config_flow.py
@@ -17,6 +17,7 @@ from custom_components.gardena_smart_system.const import (
     CONF_CLIENT_SECRET,
     CONF_LOCATION_ID,
     DOMAIN,
+    OPT_AUTO_RETRY_ON_TIMEOUT,
     OPT_DEFAULT_SOCKET_MINUTES,
     OPT_DEFAULT_WATERING_MINUTES,
     OPT_MQTT_ENABLE,
@@ -488,6 +489,7 @@ class TestOptionsFlow:
                 OPT_MQTT_TOPIC_PREFIX: "gardena",
                 OPT_MQTT_PUBLISH_STATES: True,
                 OPT_MQTT_SUBSCRIBE_COMMANDS: True,
+                OPT_AUTO_RETRY_ON_TIMEOUT: False,
             },
         )
 
@@ -531,6 +533,7 @@ class TestOptionsFlow:
                 OPT_MQTT_TOPIC_PREFIX: "gardena",
                 OPT_MQTT_PUBLISH_STATES: True,
                 OPT_MQTT_SUBSCRIBE_COMMANDS: True,
+                OPT_AUTO_RETRY_ON_TIMEOUT: False,
             },
         )
 

--- a/tests/components/gardena_smart_system/test_lawn_mower_timeout_recovery.py
+++ b/tests/components/gardena_smart_system/test_lawn_mower_timeout_recovery.py
@@ -1,0 +1,271 @@
+"""Tests for the issue #22 poll-after-timeout / opt-in retry recovery path."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.gardena_smart_system.const import OPT_AUTO_RETRY_ON_TIMEOUT
+
+from .conftest import make_mock_device
+
+_PATCH_CLIENT = "custom_components.gardena_smart_system.coordinator.GardenaClient"
+_PATCH_AUTH = "custom_components.gardena_smart_system.coordinator.GardenaAuth"
+_PATCH_WS = "custom_components.gardena_smart_system.coordinator.GardenaWebSocket"
+
+
+async def _setup_with_devices(hass, mock_config_entry, devices):
+    """Set up the integration with given device map and yield mock client."""
+    with (
+        patch(_PATCH_CLIENT) as mock_client_cls,
+        patch(_PATCH_AUTH, return_value=AsyncMock()),
+        patch(_PATCH_WS) as mock_ws_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.async_get_devices = AsyncMock(return_value=devices)
+        mock_client.async_get_websocket_url = AsyncMock(return_value="wss://test")
+        mock_client.async_send_command = AsyncMock()
+        mock_client_cls.return_value = mock_client
+        mock_ws = AsyncMock()
+        mock_ws.async_connect = AsyncMock()
+        mock_ws.async_disconnect = AsyncMock()
+        mock_ws_cls.return_value = mock_ws
+
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        yield mock_client
+
+
+def _push_state_then_raise(coordinator, device, target_activity, exc):
+    """Build a side_effect that mutates coordinator data, then raises ``exc``.
+
+    Simulates the real-world race the recovery path was designed for: the
+    Gardena cloud accepted the command and pushed the activity update via
+    WebSocket, but the HTTP response itself did not arrive in time.
+    """
+
+    def _side_effect(*_args: Any, **_kwargs: Any) -> None:
+        device.mower.activity = target_activity
+        coordinator.async_set_updated_data({device.device_id: device})
+        raise exc
+
+    return _side_effect
+
+
+class TestTimeoutRecovery:
+    """Issue #22 Feature 1: poll-after-timeout."""
+
+    async def test_recovery_when_state_reaches_target(
+        self, hass: HomeAssistant, mock_config_entry: object
+    ) -> None:
+        """Client-timeout but device reached OK_CUTTING — error is suppressed."""
+        from aiogardenasmart.exceptions import GardenaConnectionError
+
+        device = make_mock_device(has_sensor=False, has_mower=True)
+        devices = {device.device_id: device}
+
+        async for mock_client in _setup_with_devices(hass, mock_config_entry, devices):
+            coordinator = mock_config_entry.runtime_data
+            mock_client.async_send_command.side_effect = _push_state_then_raise(
+                coordinator,
+                device,
+                "OK_CUTTING",
+                GardenaConnectionError("Timeout"),
+            )
+
+            await hass.services.async_call(
+                "lawn_mower",
+                "start_mowing",
+                {"entity_id": "lawn_mower.my_sensor_mower"},
+                blocking=True,
+            )
+
+            assert mock_client.async_send_command.call_count == 1
+
+    @pytest.mark.parametrize("status", [502, 503, 504])
+    async def test_recovery_for_gateway_5xx(
+        self, hass: HomeAssistant, mock_config_entry: object, status: int
+    ) -> None:
+        """5xx upstream timeouts use the same recovery path as connection errors."""
+        from aiogardenasmart.exceptions import GardenaRequestError
+
+        device = make_mock_device(has_sensor=False, has_mower=True)
+        devices = {device.device_id: device}
+
+        async for mock_client in _setup_with_devices(hass, mock_config_entry, devices):
+            coordinator = mock_config_entry.runtime_data
+            mock_client.async_send_command.side_effect = _push_state_then_raise(
+                coordinator,
+                device,
+                "OK_CUTTING",
+                GardenaRequestError(status, "gateway timeout"),
+            )
+
+            await hass.services.async_call(
+                "lawn_mower",
+                "start_mowing",
+                {"entity_id": "lawn_mower.my_sensor_mower"},
+                blocking=True,
+            )
+
+            assert mock_client.async_send_command.call_count == 1
+
+    async def test_no_recovery_no_retry_raises_command_timeout(
+        self, hass: HomeAssistant, mock_config_entry: object
+    ) -> None:
+        """No state change + retry disabled → command_timeout error, no second call."""
+        from aiogardenasmart.exceptions import GardenaConnectionError
+
+        device = make_mock_device(has_sensor=False, has_mower=True)
+        devices = {device.device_id: device}
+
+        async for mock_client in _setup_with_devices(hass, mock_config_entry, devices):
+            mock_client.async_send_command.side_effect = GardenaConnectionError("Timeout")
+
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await hass.services.async_call(
+                    "lawn_mower",
+                    "start_mowing",
+                    {"entity_id": "lawn_mower.my_sensor_mower"},
+                    blocking=True,
+                )
+
+            assert exc_info.value.translation_key == "command_timeout"
+            assert mock_client.async_send_command.call_count == 1
+
+
+class TestTimeoutRetry:
+    """Issue #22 Feature 2: opt-in auto-retry."""
+
+    async def test_retry_succeeds_when_second_call_lands(
+        self, hass: HomeAssistant, mock_config_entry: object
+    ) -> None:
+        """First call times out, second call returns cleanly and state arrives."""
+        from aiogardenasmart.exceptions import GardenaConnectionError
+
+        device = make_mock_device(has_sensor=False, has_mower=True)
+        devices = {device.device_id: device}
+
+        async for mock_client in _setup_with_devices(hass, mock_config_entry, devices):
+            hass.config_entries.async_update_entry(
+                mock_config_entry,
+                options={**mock_config_entry.options, OPT_AUTO_RETRY_ON_TIMEOUT: True},
+            )
+            await hass.async_block_till_done()
+
+            coordinator = mock_config_entry.runtime_data
+            calls: list[int] = []
+
+            def _side_effect(*_args: Any, **_kwargs: Any) -> None:
+                calls.append(1)
+                if len(calls) == 1:
+                    # First call: simulate dropped HTTP response, no state change.
+                    raise GardenaConnectionError("Timeout")
+                # Second call: server accepts, push the state update.
+                device.mower.activity = "OK_CUTTING"
+                coordinator.async_set_updated_data({device.device_id: device})
+
+            mock_client.async_send_command.side_effect = _side_effect
+
+            await hass.services.async_call(
+                "lawn_mower",
+                "start_mowing",
+                {"entity_id": "lawn_mower.my_sensor_mower"},
+                blocking=True,
+            )
+
+            assert mock_client.async_send_command.call_count == 2
+
+    async def test_retry_disabled_does_not_call_twice(
+        self, hass: HomeAssistant, mock_config_entry: object
+    ) -> None:
+        """Retry must stay opt-in — without the option, no second call is made."""
+        from aiogardenasmart.exceptions import GardenaConnectionError
+
+        device = make_mock_device(has_sensor=False, has_mower=True)
+        devices = {device.device_id: device}
+
+        async for mock_client in _setup_with_devices(hass, mock_config_entry, devices):
+            mock_client.async_send_command.side_effect = GardenaConnectionError("Timeout")
+
+            with pytest.raises(HomeAssistantError):
+                await hass.services.async_call(
+                    "lawn_mower",
+                    "start_mowing",
+                    {"entity_id": "lawn_mower.my_sensor_mower"},
+                    blocking=True,
+                )
+
+            assert mock_client.async_send_command.call_count == 1
+
+    async def test_retry_enabled_but_still_no_state_change_raises_timeout(
+        self, hass: HomeAssistant, mock_config_entry: object
+    ) -> None:
+        """Retry succeeds at the API level but the device never confirms the state."""
+        from aiogardenasmart.exceptions import GardenaConnectionError
+
+        device = make_mock_device(has_sensor=False, has_mower=True)
+        devices = {device.device_id: device}
+
+        async for mock_client in _setup_with_devices(hass, mock_config_entry, devices):
+            hass.config_entries.async_update_entry(
+                mock_config_entry,
+                options={**mock_config_entry.options, OPT_AUTO_RETRY_ON_TIMEOUT: True},
+            )
+            await hass.async_block_till_done()
+
+            calls: list[int] = []
+
+            def _side_effect(*_args: Any, **_kwargs: Any) -> None:
+                calls.append(1)
+                if len(calls) == 1:
+                    raise GardenaConnectionError("Timeout")
+                # Second call returns cleanly but device state never changes.
+
+            mock_client.async_send_command.side_effect = _side_effect
+
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await hass.services.async_call(
+                    "lawn_mower",
+                    "start_mowing",
+                    {"entity_id": "lawn_mower.my_sensor_mower"},
+                    blocking=True,
+                )
+
+            assert exc_info.value.translation_key == "command_timeout"
+            assert mock_client.async_send_command.call_count == 2
+
+    async def test_retry_second_call_fails_too(
+        self, hass: HomeAssistant, mock_config_entry: object
+    ) -> None:
+        """Both calls fail — exactly two API calls, then a translated error."""
+        from aiogardenasmart.exceptions import GardenaConnectionError
+
+        device = make_mock_device(has_sensor=False, has_mower=True)
+        devices = {device.device_id: device}
+
+        async for mock_client in _setup_with_devices(hass, mock_config_entry, devices):
+            hass.config_entries.async_update_entry(
+                mock_config_entry,
+                options={**mock_config_entry.options, OPT_AUTO_RETRY_ON_TIMEOUT: True},
+            )
+            await hass.async_block_till_done()
+
+            mock_client.async_send_command.side_effect = GardenaConnectionError("Timeout")
+
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await hass.services.async_call(
+                    "lawn_mower",
+                    "start_mowing",
+                    {"entity_id": "lawn_mower.my_sensor_mower"},
+                    blocking=True,
+                )
+
+            assert exc_info.value.translation_key == "command_timeout"
+            assert mock_client.async_send_command.call_count == 2


### PR DESCRIPTION
## Summary

Closes #22.

After v1.12.12 made the gateway-timeout error message clearer, @w1Ngx confirmed via the trace in #22 that the new translated `command_timeout` is delivered correctly — but the underlying problem still bites users on the HACS Scheduler component: a one-shot `lawn_mower.start_mowing` call that hits an HTTP timeout simply does not start the mower, and the scheduler has no retry.

Two coordinated additions:

### 1. Poll-after-timeout (always on)

When `_async_execute_command` catches a client-side timeout / 502 / 503 / 504, it polls the coordinator for up to 10 s waiting for the WebSocket push that confirms the device reached the expected state (`OK_CUTTING` for `start_mowing`, `MANUAL_WATERING` for valve open, etc.).

- Reads in-memory coordinator state only — **no extra REST calls** are made, the API budget is unaffected.
- If the target state arrives within the window, the error is suppressed: the command actually landed, only the HTTP response was lost.
- Per-callsite `expected_state_check` lambda is built from frozensets of acceptable target activities; callsites without a target lambda keep the prior throw-immediately behaviour.

### 2. Opt-in auto-retry (default off)

New options-flow toggle `auto_retry_on_timeout`. When enabled and the 10 s poll window expires without a state change, the command is sent **exactly once more** before raising `command_timeout`.

- Default-off preserves the prior safety guarantee — no surprise double-starts.
- Users on Scheduler-style fire-and-forget setups who prefer "double-fire over no-fire" can opt in.
- The retry has its own throttle/budget increment and its own poll-after window before declaring final failure.

### Coverage

- `entity.py` (Gardena devices) and `automower_entity.py` (Husqvarna Automower) share the same exception-mapping shape — both gain the same recovery path.
- Callsites updated: `lawn_mower.py` (5 commands), `automower_lawn_mower.py` (5 commands), `switch.py` (power-socket on/off), `valve.py` (open/close).
- New tests: `test_lawn_mower_timeout_recovery.py` (4 scenarios + 5xx parametrisation) and `test_automower_timeout_recovery.py` (3 scenarios for the Automower path).
- Existing 5xx/connection-error tests for the Automower were updated to seed the device in `PARKED_IN_CS` so the recovery path cannot short-circuit on the default `MOWING` activity.
- Options-flow tests pass `auto_retry_on_timeout=False` explicitly.
- New conftest fixture collapses the 10 s poll window to 0 s for fast tests; recovery tests rely on the synchronous coordinator update before the initial check fires.

Translations updated for `de`/`en` (`auto_retry_on_timeout` label + description); other locales fall back to English until contributors translate.

## Test plan

- [x] `uv run ruff check` (clean)
- [x] `uv run ruff format` (clean)
- [x] `uv run pytest tests/components/gardena_smart_system/` → 637 passed
- [x] CHANGELOG entry added under [1.12.13] - 2026-05-05
- [x] `bug_report.yml` dropdown prepends `1.12.13`
- [x] `manifest.json` version bumped to 1.12.13
- [ ] Manual smoke test on the live HA instance with a real Gardena device (post-merge / next release cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)