### PR TITLE
deps: bump mypy lower bound to >=2.0.0 across both vendored libs

### DIFF
--- a/aioautomower/pyproject.toml
+++ b/aioautomower/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
     "aioresponses>=0.7.8",
-    "mypy>=1.20.2",
+    "mypy>=2.0.0",
     "ruff>=0.15.12",
 ]
 

--- a/aiogardenasmart/pyproject.toml
+++ b/aiogardenasmart/pyproject.toml
@@ -18,7 +18,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
     "aioresponses>=0.7",
-    "mypy>=1.9",
+    "mypy>=2.0.0",
     "ruff>=0.4",
 ]
 


### PR DESCRIPTION
## Summary
- Bumps `mypy` lower bound to `>=2.0.0` in both `aiogardenasmart/pyproject.toml` (was `>=1.9`) and `aioautomower/pyproject.toml` (was `>=1.20.2`).
- Keeps the two vendored libs in sync on a single mypy floor and matches what CI already installs unpinned via `pip install mypy` in `.github/workflows/ci.yml:110`.

## Why combined instead of #25
Supersedes #25 (which only touched `aioautomower/`). Doing both in one go avoids leaving `aiogardenasmart` on a stale mypy floor and saves a second review cycle. Close #25 once this lands.

## Risk
Dev-only dependency change. No runtime code touched, no manifest bump, no lockfile change required at repo root (mypy is not pinned in the top-level `uv.lock`). The CI `mypy` job already runs against mypy 2.0 today (latest) and is green on #25.

## Test plan
- [ ] CI: Ruff, mypy, Tests (Py 3.13), Hassfest, HACS Validation, Library version sync all green
- [ ] Confirm Dependabot does not immediately reopen #25 against a now-equal-or-stricter constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)