### PR TITLE
v2.0.2: version bump (v2.0.1 tag burned by immutable releases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to the Gardena Smart System integration for Home Assistant.
 
-## [2.0.1] - 2026-05-16
+## [2.0.2] - 2026-05-16
+
+> **Note:** Version 2.0.1 was skipped. A release-tooling mishap published and then deleted a `v2.0.1` tag; with immutable releases enabled the tag name is permanently reserved and cannot point to the correct commit, so this change ships as 2.0.2. No 2.0.1 was ever installable.
 
 ### Added
 - **Bundled brand assets** under `custom_components/gardena_smart_system_ng/brand/` (`icon.png`, `icon@2x.png`, `logo.png`, `logo@2x.png`). As of Home Assistant 2026.3.0, custom integrations ship their own brand images instead of registering them in the `home-assistant/brands` repository (which no longer accepts custom-integration icons). This restores the GARDENA icon/logo lost in the v2.0.0 domain rename and satisfies the HACS `brands` validation. Same GARDENA artwork as before — no visual change for users.

--- a/custom_components/gardena_smart_system_ng/manifest.json
+++ b/custom_components/gardena_smart_system_ng/manifest.json
@@ -12,5 +12,5 @@
   "quality_scale": "platinum",
   "requirements": ["aiogardenasmart==0.1.9"],
   "single_config_entry": false,
-  "version": "2.0.1"
+  "version": "2.0.2"
 }


### PR DESCRIPTION
Bumps `2.0.1` → `2.0.2` in manifest + CHANGELOG. The brand-assets change already merged to main as 2.0.1, but a release-tooling mishap published and deleted a `v2.0.1` tag pointing at the wrong commit; with immutable releases enabled that tag name is permanently reserved. No 2.0.1 was ever installable. Content is identical to the intended 2.0.1.

No code/behaviour change. Full local CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)