### PR TITLE
Local GARDENA smart Gateway access (local-first control)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e ./aiogardenasmart -e ./aioautomower
+          pip install gardena-smart-local-api==0.0.11
           pip install pytest pytest-asyncio pytest-cov pytest-homeassistant-custom-component
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ To use both APIs, add the integration twice with the same credentials.
 | Troubleshooting | [Wiki / Troubleshooting](https://github.com/kayloehmann/ha-gardena-smart-system/wiki/Troubleshooting-EN) |
 | Contributing | [Wiki / Contributing](https://github.com/kayloehmann/ha-gardena-smart-system/wiki/Contributing-EN) |
 
+### Local access (preview)
+
+Talk to the GARDENA smart Gateway directly over your LAN, alongside the cloud. When enabled and reachable, **local state takes precedence** over the cloud and **commands are sent locally first** (the cloud stays as the fallback) — lower latency, and monitoring/control keep working during a cloud or internet outage. Built on the official [`gardena-smart-local-api`](https://github.com/cloudless-garden/gardena-smart-local-api) (GARDENA GmbH).
+
+**One-time gateway setup (required).** The gateway's local WebSocket service is off by default and can only be enabled via shell on the gateway itself — the integration cannot do it. After enabling SSH on the gateway:
+
+```sh
+touch /etc/enable-websocketd   # survives reboots and firmware updates
+systemctl restart firewall     # opens 8443/TCP — easy to forget!
+systemctl start websocketd
+```
+
+**Integration setup.** Settings → Devices & Services → Gardena → *Configure*, then set **Enable local gateway access**, the **host/IP** (e.g. `10.0.0.5` or `GARDENA-xxxxxx.local`), the **password** (the first 8 characters of the gateway's device id, printed on the underside), and the **port** (default `8443`).
+
+Two entities surface the behaviour: a **Local gateway connected** binary sensor and a per-device **Last command via** (`local`/`cloud`) diagnostic sensor.
+
+Notes: the gateway uses a self-signed certificate (verification is disabled for it) and sends no initial state snapshot, so the cloud still provides the initial device state after a restart. If Home Assistant sits on a different VLAN than the gateway, allow it to reach the gateway on TCP 8443.
+
 ---
 
 ## Deutsch
@@ -69,6 +87,24 @@ Um beide APIs zu nutzen, die Integration zweimal mit denselben Zugangsdaten hinz
 | Einschränkungen | [Wiki / Einschränkungen](https://github.com/kayloehmann/ha-gardena-smart-system/wiki/Limitations-DE) |
 | Fehlerbehebung | [Wiki / Fehlerbehebung](https://github.com/kayloehmann/ha-gardena-smart-system/wiki/Troubleshooting-DE) |
 | Mitwirken | [Wiki / Mitwirken](https://github.com/kayloehmann/ha-gardena-smart-system/wiki/Contributing-DE) |
+
+### Lokaler Zugriff (Vorschau)
+
+Direkt mit dem GARDENA smart Gateway über das LAN kommunizieren, parallel zur Cloud. Wenn aktiviert und erreichbar, hat der **lokale Zustand Vorrang** vor der Cloud und **Befehle gehen zuerst lokal** raus (die Cloud bleibt Fallback) — geringere Latenz, und Überwachung/Steuerung funktionieren auch bei Cloud- oder Internet-Ausfall weiter. Basiert auf der offiziellen [`gardena-smart-local-api`](https://github.com/cloudless-garden/gardena-smart-local-api) (GARDENA GmbH).
+
+**Einmalige Gateway-Einrichtung (erforderlich).** Der lokale WebSocket-Dienst des Gateways ist standardmäßig aus und lässt sich nur per Shell am Gateway selbst aktivieren — die Integration kann das nicht. Nach dem Aktivieren von SSH am Gateway:
+
+```sh
+touch /etc/enable-websocketd   # übersteht Reboots und Firmware-Updates
+systemctl restart firewall     # gibt 8443/TCP frei — leicht zu vergessen!
+systemctl start websocketd
+```
+
+**Einrichtung in der Integration.** Einstellungen → Geräte & Dienste → Gardena → *Konfigurieren*, dann **Lokalen Gateway-Zugriff aktivieren**, **Host/IP** (z. B. `10.0.0.5` oder `GARDENA-xxxxxx.local`), **Passwort** (die ersten 8 Zeichen der Geräte-ID vom Aufkleber) und **Port** (Standard `8443`) setzen.
+
+Zwei Entitäten machen das sichtbar: ein Binary-Sensor **Lokales Gateway verbunden** und ein Diagnose-Sensor **Letzter Befehl über** (`local`/`cloud`) je Gerät.
+
+Hinweise: Das Gateway nutzt ein selbstsigniertes Zertifikat (Verifikation dafür deaktiviert) und sendet keinen initialen Zustands-Snapshot — der Anfangszustand kommt nach einem Neustart weiter aus der Cloud. Liegt Home Assistant in einem anderen VLAN als das Gateway, muss der Zugriff auf TCP 8443 freigegeben werden.
 
 ---
 

--- a/custom_components/gardena_smart_system_ng/binary_sensor.py
+++ b/custom_components/gardena_smart_system_ng/binary_sensor.py
@@ -22,7 +22,7 @@ from aiogardenasmart import Device
 
 from . import GardenaConfigEntry
 from .base_coordinator import BaseSmartSystemCoordinator
-from .const import API_TYPE_AUTOMOWER, CONF_API_TYPE
+from .const import API_TYPE_AUTOMOWER, CONF_API_TYPE, OPT_LOCAL_ENABLE
 from .coordinator import GardenaCoordinator
 from .entity import GardenaEntity
 
@@ -128,6 +128,10 @@ async def async_setup_entry(
 
     async_add_entities([HubWebSocketSensor(coordinator, entry, _hub_device_info)])
 
+    # Local gateway connection status — only relevant when local access is on.
+    if entry.options.get(OPT_LOCAL_ENABLE):
+        async_add_entities([HubLocalConnectionSensor(coordinator, entry, _hub_device_info)])
+
 
 class GardenaBinarySensorEntity(GardenaEntity, BinarySensorEntity):
     """A binary sensor entity for Gardena Smart System devices."""
@@ -177,3 +181,29 @@ class HubWebSocketSensor(CoordinatorEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return True if the WebSocket is connected."""
         return self.coordinator.ws_connected
+
+
+class HubLocalConnectionSensor(CoordinatorEntity, BinarySensorEntity):
+    """Local GARDENA smart Gateway connection status for the integration hub."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "hub_local_connected"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    coordinator: GardenaCoordinator
+
+    def __init__(
+        self,
+        coordinator: GardenaCoordinator,
+        entry: GardenaConfigEntry,
+        device_info_fn: Callable[[GardenaConfigEntry], DeviceInfo],
+    ) -> None:
+        """Initialize the local connection sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"hub_{entry.entry_id}_local_connected"
+        self._attr_device_info = device_info_fn(entry)
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the local gateway link is up."""
+        return self.coordinator.local_connected

--- a/custom_components/gardena_smart_system_ng/config_flow.py
+++ b/custom_components/gardena_smart_system_ng/config_flow.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     CONF_LOCATION_ID,
+    DEFAULT_LOCAL_PORT,
     DEFAULT_MQTT_TOPIC_PREFIX,
     DEFAULT_POLL_INTERVAL_AUTOMOWER,
     DEFAULT_POLL_INTERVAL_GARDENA,
@@ -55,6 +56,10 @@ from .const import (
     MIN_POLL_INTERVAL,
     OPT_DEFAULT_SOCKET_MINUTES,
     OPT_DEFAULT_WATERING_MINUTES,
+    OPT_LOCAL_ENABLE,
+    OPT_LOCAL_HOST,
+    OPT_LOCAL_PASSWORD,
+    OPT_LOCAL_PORT,
     OPT_MQTT_ENABLE,
     OPT_MQTT_PUBLISH_STATES,
     OPT_MQTT_SUBSCRIBE_COMMANDS,
@@ -527,7 +532,7 @@ class GardenaOptionsFlowHandler(OptionsFlow):
         current_poll = self.config_entry.options.get(OPT_POLL_INTERVAL_MINUTES, default_poll)
 
         if is_automower:
-            schema_dict: dict[vol.Required, Any] = {}
+            schema_dict: dict[vol.Marker, Any] = {}
         else:
             current_watering = self.config_entry.options.get(
                 OPT_DEFAULT_WATERING_MINUTES, DEFAULT_WATERING_MINUTES
@@ -593,6 +598,25 @@ class GardenaOptionsFlowHandler(OptionsFlow):
         schema_dict[vol.Required(OPT_MQTT_PUBLISH_STATES)] = BooleanSelector()
         schema_dict[vol.Required(OPT_MQTT_SUBSCRIBE_COMMANDS)] = BooleanSelector()
 
+        # Local gateway options (Gardena only). The websocketd service must be
+        # enabled once on the gateway via shell; here we only collect host +
+        # password. An empty host (or the toggle off) keeps the channel disabled.
+        if not is_automower:
+            current_local_enable = self.config_entry.options.get(OPT_LOCAL_ENABLE, False)
+            current_local_host = self.config_entry.options.get(OPT_LOCAL_HOST, "")
+            current_local_password = self.config_entry.options.get(OPT_LOCAL_PASSWORD, "")
+            current_local_port = self.config_entry.options.get(OPT_LOCAL_PORT, DEFAULT_LOCAL_PORT)
+            schema_dict[vol.Optional(OPT_LOCAL_ENABLE, default=False)] = BooleanSelector()
+            schema_dict[vol.Optional(OPT_LOCAL_HOST)] = TextSelector(
+                TextSelectorConfig(type=TextSelectorType.TEXT)
+            )
+            schema_dict[vol.Optional(OPT_LOCAL_PASSWORD)] = TextSelector(
+                TextSelectorConfig(type=TextSelectorType.PASSWORD)
+            )
+            schema_dict[vol.Optional(OPT_LOCAL_PORT, default=DEFAULT_LOCAL_PORT)] = NumberSelector(
+                NumberSelectorConfig(min=1, max=65535, step=1, mode=NumberSelectorMode.BOX)
+            )
+
         suggested_values: dict[str, Any] = {
             OPT_POLL_INTERVAL_MINUTES: current_poll,
             OPT_MQTT_ENABLE: current_mqtt,
@@ -604,6 +628,10 @@ class GardenaOptionsFlowHandler(OptionsFlow):
             suggested_values[OPT_DEFAULT_WATERING_MINUTES] = current_watering
             suggested_values[OPT_DEFAULT_SOCKET_MINUTES] = current_socket
             suggested_values[OPT_START_MOWING_DURATION_MINUTES] = current_start_mowing
+            suggested_values[OPT_LOCAL_ENABLE] = current_local_enable
+            suggested_values[OPT_LOCAL_HOST] = current_local_host
+            suggested_values[OPT_LOCAL_PASSWORD] = current_local_password
+            suggested_values[OPT_LOCAL_PORT] = current_local_port
 
         schema = self.add_suggested_values_to_schema(
             vol.Schema(schema_dict),

--- a/custom_components/gardena_smart_system_ng/const.py
+++ b/custom_components/gardena_smart_system_ng/const.py
@@ -167,6 +167,39 @@ COMMAND_RETRY_ATTEMPTS = 3
 COMMAND_POLL_AFTER_TIMEOUT_SECONDS = 15.0
 COMMAND_POLL_INTERVAL_SECONDS = 1.0
 
+# ── Local WebSocket access (GARDENA smart Gateway) ───────────────
+# Optional second channel: a direct WebSocket to the GARDENA smart Gateway
+# (websocketd, port 8443) via the official `gardena-smart-local-api` library.
+# When enabled AND reachable, local state pushes take PRECEDENCE over the cloud
+# WebSocket (lower latency, works during a cloud/internet outage) and commands
+# are routed LOCAL-FIRST, falling back to the cloud command path only when the
+# local channel is unavailable or the local send is not acknowledged.
+#
+# The gateway's websocketd service must be enabled once via shell on the gateway
+# itself (touch /etc/enable-websocketd + restart firewall + start websocketd) —
+# the integration cannot do this. The config flow only asks for host + password.
+# The gateway has NO initial state dump, so the cloud REST/WS remains the source
+# of the initial device set; local is a live-update + command OVERLAY.
+OPT_LOCAL_ENABLE = "local_enable"
+OPT_LOCAL_HOST = "local_host"
+OPT_LOCAL_PASSWORD = "local_password"  # option key, not a secret value
+OPT_LOCAL_PORT = "local_port"
+DEFAULT_LOCAL_PORT = 8443
+# Password = first 8 characters of the gateway's device id (printed on the
+# underside); the websocketd Basic-Auth checks only the password, not the user.
+LOCAL_PASSWORD_LENGTH = 8
+# Cloud device serials are the SGTIN96 EPC serial of the local device id, zero-
+# padded to 8 digits — e.g. local `3034F8EE901E…` → serial 4756 → "00004756".
+# This is how a local device is matched to its existing cloud-side entities.
+LOCAL_SERIAL_PAD_WIDTH = 8
+# Local reconnect ladder (seconds). The gateway is on the LAN, so reconnects are
+# cheap and carry no API-budget cost (unlike the cloud WS) — retry briskly.
+LOCAL_RECONNECT_SCHEDULE = (1, 2, 5, 10, 30, 60)
+# Local command acknowledgement timeout. The gateway replies with a Reply frame
+# (matching request_id) within well under a second on the LAN; if no ack arrives
+# in this window the local send is considered failed and the cloud path is used.
+LOCAL_COMMAND_ACK_TIMEOUT_SECONDS = 5.0
+
 # ── MQTT bridge options ──────────────────────────────────────────
 OPT_MQTT_ENABLE = "mqtt_enable"
 OPT_MQTT_TOPIC_PREFIX = "mqtt_topic_prefix"

--- a/custom_components/gardena_smart_system_ng/coordinator.py
+++ b/custom_components/gardena_smart_system_ng/coordinator.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
 from aiogardenasmart import (
@@ -26,11 +26,22 @@ from .const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     CONF_LOCATION_ID,
+    DEFAULT_LOCAL_PORT,
     DEFAULT_POLL_INTERVAL_GARDENA,
     DOMAIN,
+    OPT_LOCAL_ENABLE,
+    OPT_LOCAL_HOST,
+    OPT_LOCAL_PASSWORD,
+    OPT_LOCAL_PORT,
     RATE_LIMIT_COOLDOWN,
     SCAN_INTERVAL,
     SCAN_INTERVAL_WS_CONNECTED,
+)
+from .local_channel import GardenaLocalChannel
+from .local_translate import (
+    apply_local_state,
+    build_local_command,
+    index_local_devices_by_serial,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,6 +82,11 @@ class GardenaCoordinator(BaseSmartSystemCoordinator[Device]):
         super().__init__(hass, entry, websession, auth, _GARDENA_CONFIG)
         self._client = GardenaClient(auth, websession)
         self._location_id: str = entry.data[CONF_LOCATION_ID]
+        # Optional local gateway channel (see local_channel / local_translate).
+        self._local_channel: GardenaLocalChannel | None = None
+        self._local_connected = False
+        # device_id -> "local" | "cloud": route the last command actually took.
+        self._last_command_source: dict[str, str] = {}
 
     @property
     def location_id(self) -> str:
@@ -84,7 +100,128 @@ class GardenaCoordinator(BaseSmartSystemCoordinator[Device]):
 
     async def _async_fetch_devices(self) -> dict[str, Device]:
         """Fetch devices from the Gardena API."""
-        return await self._client.async_get_devices(self._location_id)
+        devices = await self._client.async_get_devices(self._location_id)
+        await self._async_ensure_local_channel()
+        return devices
+
+    # ── Local gateway channel (optional, takes precedence) ─────────
+    @property
+    def local_connected(self) -> bool:
+        """Whether the local gateway link is currently up."""
+        return self._local_connected
+
+    def last_command_source(self, device_id: str) -> str | None:
+        """Return 'local' or 'cloud' for the most recent command to a device."""
+        return self._last_command_source.get(device_id)
+
+    async def _async_ensure_local_channel(self) -> None:
+        """Start, stop, or leave the local channel per the current options."""
+        options = self.config_entry.options
+        host = options.get(OPT_LOCAL_HOST)
+        if not options.get(OPT_LOCAL_ENABLE) or not host:
+            if self._local_channel is not None:
+                await self._local_channel.async_stop()
+                self._local_channel = None
+                self._set_local_connected(False)
+            return
+        if self._local_channel is None:
+            self._local_channel = GardenaLocalChannel(
+                self.hass,
+                host,
+                options.get(OPT_LOCAL_PASSWORD, ""),
+                int(options.get(OPT_LOCAL_PORT, DEFAULT_LOCAL_PORT)),
+                on_devices_updated=self._on_local_devices_updated,
+                on_connection_change=self._set_local_connected,
+            )
+            await self._local_channel.async_start()
+
+    @callback
+    def _on_local_devices_updated(self, local_devices: Any) -> None:
+        """Overlay fresh local state onto the cloud model (local takes precedence)."""
+        self._apply_local_overlay(local_devices)
+
+    def _apply_local_overlay(self, local_devices: Any) -> None:
+        if not self.data:
+            return
+        by_serial = index_local_devices_by_serial(local_devices)
+        changed = False
+        for device in self.data.values():
+            local = by_serial.get(device.serial)
+            if local is not None and apply_local_state(local, device):
+                changed = True
+        if changed:
+            self.async_set_updated_data(self.data)
+
+    @callback
+    def _set_local_connected(self, value: bool) -> None:
+        if value != self._local_connected:
+            self._local_connected = value
+            self.async_update_listeners()
+
+    def _on_device_update(self, device_id: str, device: Device) -> None:
+        """Apply the cloud push, then re-assert local state so local wins."""
+        super()._on_device_update(device_id, device)
+        channel = self._local_channel
+        if channel is None or not channel.connected or not self.data:
+            return
+        cloud_device = self.data.get(device_id)
+        if cloud_device is None:
+            return
+        local = index_local_devices_by_serial(channel.devices).get(cloud_device.serial)
+        if local is not None and apply_local_state(local, cloud_device):
+            self.async_set_updated_data(self.data)
+
+    async def async_send_command(
+        self, service_id: str, control_type: str, command: str, **params: int
+    ) -> None:
+        """Send a device command local-first, falling back to the cloud API.
+
+        Mirrors ``client.async_send_command`` so entity platforms can call it in
+        place of the cloud client. Records which route actually carried the
+        command (see ``last_command_source``). A cloud-path failure propagates
+        exactly as before so the existing retry/timeout logic is unaffected.
+        """
+        device_id = service_id.split(":")[0]
+        if await self._try_local_command(device_id, service_id, control_type, command, params):
+            self._last_command_source[device_id] = "local"
+            return
+        # Forward as keywords to preserve the exact cloud-client call convention.
+        await self._client.async_send_command(
+            service_id=service_id, control_type=control_type, command=command, **params
+        )
+        self._last_command_source[device_id] = "cloud"
+
+    async def _try_local_command(
+        self,
+        device_id: str,
+        service_id: str,
+        control_type: str,
+        command: str,
+        params: dict[str, int],
+    ) -> bool:
+        """Attempt the command over the local channel; True only if acknowledged."""
+        channel = self._local_channel
+        if channel is None or not channel.connected or not self.data:
+            return False
+        cloud_device = self.data.get(device_id)
+        if cloud_device is None:
+            return False
+        local = index_local_devices_by_serial(channel.devices).get(cloud_device.serial)
+        if local is None:
+            return False
+        request = build_local_command(
+            local, cloud_device, service_id, control_type, command, params.get("seconds")
+        )
+        if request is None:
+            return False
+        return await channel.async_send_command(request)
+
+    async def async_shutdown(self) -> None:
+        """Stop the local channel, then run the shared shutdown."""
+        if self._local_channel is not None:
+            await self._local_channel.async_stop()
+            self._local_channel = None
+        await super().async_shutdown()
 
     async def _async_get_ws_url(self, devices: dict[str, Device]) -> str:
         """Obtain the WebSocket URL from the Gardena API."""

--- a/custom_components/gardena_smart_system_ng/coordinator.py
+++ b/custom_components/gardena_smart_system_ng/coordinator.py
@@ -164,11 +164,8 @@ class GardenaCoordinator(BaseSmartSystemCoordinator[Device]):
         channel = self._local_channel
         if channel is None or not channel.connected or not self.data:
             return
-        cloud_device = self.data.get(device_id)
-        if cloud_device is None:
-            return
-        local = index_local_devices_by_serial(channel.devices).get(cloud_device.serial)
-        if local is not None and apply_local_state(local, cloud_device):
+        local = index_local_devices_by_serial(channel.devices).get(device.serial)
+        if local is not None and apply_local_state(local, device):
             self.async_set_updated_data(self.data)
 
     async def async_send_command(

--- a/custom_components/gardena_smart_system_ng/diagnostics.py
+++ b/custom_components/gardena_smart_system_ng/diagnostics.py
@@ -15,6 +15,7 @@ from .const import API_TYPE_AUTOMOWER, CONF_API_TYPE
 TO_REDACT = {
     "client_id",
     "client_secret",
+    "local_password",
     "serial",
     "serial_number",
     "location_id",
@@ -53,6 +54,7 @@ async def async_get_config_entry_diagnostics(
     else:
         coordinator_info["location_id"] = "**REDACTED**"
         coordinator_info["stale_miss_counts"] = dict(coordinator.stale_miss_counts)
+        coordinator_info["local_connected"] = getattr(coordinator, "local_connected", None)
 
     return async_redact_data(
         {

--- a/custom_components/gardena_smart_system_ng/lawn_mower.py
+++ b/custom_components/gardena_smart_system_ng/lawn_mower.py
@@ -228,7 +228,7 @@ class GardenaLawnMowerEntity(GardenaEntity, LawnMowerEntity):
                 translation_key="device_unavailable",
             )
         await self._async_execute_command(
-            self.coordinator.client.async_send_command,
+            self.coordinator.async_send_command,
             service_id=device.mower.service_id,
             control_type=ControlType.MOWER,
             command=command,

--- a/custom_components/gardena_smart_system_ng/local_channel.py
+++ b/custom_components/gardena_smart_system_ng/local_channel.py
@@ -171,7 +171,7 @@ class GardenaLocalChannel:
     async def _session_once(self) -> None:
         """One connection lifetime: connect, discover, pump events until close."""
         ssl_ctx = self._ssl
-        if ssl_ctx is None:  # async_start sets it first; narrow for the type checker
+        if ssl_ctx is None:  # pragma: no cover - async_start always sets _ssl first
             ssl_ctx = await self._hass.async_add_executor_job(get_default_no_verify_context)
             self._ssl = ssl_ctx
         async with self._session.ws_connect(

--- a/custom_components/gardena_smart_system_ng/local_channel.py
+++ b/custom_components/gardena_smart_system_ng/local_channel.py
@@ -1,0 +1,310 @@
+"""Local WebSocket channel to the GARDENA smart Gateway.
+
+The official ``gardena-smart-local-api`` is a protocol/model library, not a
+transport: it parses/builds frames and models devices, but the WebSocket
+connection itself is the consumer's responsibility. This module is that
+transport, adapted to Home Assistant conventions and this integration's needs:
+
+* Connects over the **shared HA aiohttp session** (``async_get_clientsession``)
+  so the Platinum ``inject-websession`` rule holds for the local path too.
+* Self-signed gateway certificate → HA's ``get_default_no_verify_context``.
+* **No application-level pings.** The reference client uses ``heartbeat=30``,
+  but this gateway firmware (10.4.4) answers WS PING control frames with a
+  ``Received non-text data`` error frame (verified live), so we disable
+  heartbeat and use a lightweight text ``read`` keepalive instead.
+* Cheap LAN reconnects (``LOCAL_RECONNECT_SCHEDULE``) — unlike the cloud WS,
+  a local reconnect costs no API budget.
+
+The channel owns the connection and the local ``DeviceMap`` and calls back into
+its owner (the Gardena coordinator) on every state change and connection-state
+change; translating local device state onto the cloud device model is the
+owner's job, not this module's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import logging
+from collections.abc import Callable
+from ssl import SSLContext
+from typing import Any
+
+import aiohttp
+from gardena_smart_local_api.devices import (
+    DeviceMap,
+    build_discovery_obj,
+    create_devices_from_messages,
+)
+from gardena_smart_local_api.messages import (
+    EgressMessageList,
+    ErrorMessage,
+    Event,
+    IngressMessageList,
+    Reply,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import get_default_no_verify_context
+
+from .const import (
+    DEFAULT_LOCAL_PORT,
+    LOCAL_COMMAND_ACK_TIMEOUT_SECONDS,
+    LOCAL_RECONNECT_SCHEDULE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DISCOVERY_TIMEOUT_SECONDS = 30.0
+# Keepalive cadence: a quiet garden sends no events, so we periodically read a
+# cheap resource to prove the link is alive (and detect a silently-dead socket).
+KEEPALIVE_INTERVAL_SECONDS = 60.0
+
+
+class GardenaLocalChannel:
+    """Owns the local gateway WebSocket connection and device state."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        host: str,
+        password: str,
+        port: int = DEFAULT_LOCAL_PORT,
+        *,
+        on_devices_updated: Callable[[DeviceMap], None],
+        on_connection_change: Callable[[bool], None],
+    ) -> None:
+        """Initialise the channel; ``async_start`` opens the connection."""
+        self._hass = hass
+        self._host = host
+        self._port = port
+        self._uri = f"wss://{host}:{port}"
+        self._auth = base64.b64encode(f"_:{password}".encode()).decode("ascii")
+        self._on_devices_updated = on_devices_updated
+        self._on_connection_change = on_connection_change
+
+        self._session = async_get_clientsession(hass)
+        self._ssl: SSLContext | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._runner: asyncio.Task[None] | None = None
+        self._connected = False
+        self.devices: DeviceMap = DeviceMap({})
+        # request_id -> future resolved with the matching Reply
+        self._pending: dict[str, asyncio.Future[Reply]] = {}
+
+    # ── public API ────────────────────────────────────────────────
+    @property
+    def connected(self) -> bool:
+        """Whether the local gateway link is currently up."""
+        return self._connected
+
+    async def async_start(self) -> None:
+        """Start the background connect/reconnect loop (idempotent)."""
+        if self._runner is None or self._runner.done():
+            # Building the SSL context loads CA files (blocking); do it in the
+            # executor per HA guidance rather than on the event loop.
+            if self._ssl is None:
+                self._ssl = await self._hass.async_add_executor_job(get_default_no_verify_context)
+            self._runner = self._hass.async_create_background_task(
+                self._run(), "gardena_ng_local_channel"
+            )
+
+    async def async_stop(self) -> None:
+        """Stop the channel and drop the connection."""
+        runner, self._runner = self._runner, None
+        if runner is not None:
+            runner.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await runner
+        self._set_connected(False)
+
+    async def async_send_command(self, request: EgressMessageList) -> bool:
+        """Send a command and await its acknowledgement.
+
+        Returns ``True`` only if every request in ``request`` is acknowledged
+        with ``success`` within ``LOCAL_COMMAND_ACK_TIMEOUT_SECONDS``. Any
+        failure (no connection, timeout, error reply) returns ``False`` so the
+        caller can fall back to the cloud command path.
+        """
+        ws = self._ws
+        if ws is None or ws.closed:
+            return False
+        request_ids = [r.request_id for r in request.root if r.request_id is not None]
+        if not request_ids:
+            return False
+        loop = asyncio.get_running_loop()
+        futures: dict[str, asyncio.Future[Reply]] = {
+            rid: loop.create_future() for rid in request_ids
+        }
+        self._pending.update(futures)
+        try:
+            await ws.send_str(request.model_dump_json())
+            async with asyncio.timeout(LOCAL_COMMAND_ACK_TIMEOUT_SECONDS):
+                replies = await asyncio.gather(*futures.values())
+        except (TimeoutError, aiohttp.ClientError, RuntimeError) as err:
+            _LOGGER.debug("Local command failed (%s), cloud fallback applies", err)
+            return False
+        finally:
+            for rid in request_ids:
+                self._pending.pop(rid, None)
+        return all(bool(reply.success) for reply in replies)
+
+    # ── connection loop ───────────────────────────────────────────
+    async def _run(self) -> None:
+        attempt = 0
+        while True:
+            try:
+                await self._session_once()
+                attempt = 0  # a clean session resets the backoff ladder
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                _LOGGER.debug("Local gateway connection error: %s", err)
+            finally:
+                self._set_connected(False)
+                self._fail_pending()
+            delay = LOCAL_RECONNECT_SCHEDULE[min(attempt, len(LOCAL_RECONNECT_SCHEDULE) - 1)]
+            attempt += 1
+            await asyncio.sleep(delay)
+
+    async def _session_once(self) -> None:
+        """One connection lifetime: connect, discover, pump events until close."""
+        ssl_ctx = self._ssl
+        if ssl_ctx is None:  # async_start sets it first; narrow for the type checker
+            ssl_ctx = await self._hass.async_add_executor_job(get_default_no_verify_context)
+            self._ssl = ssl_ctx
+        async with self._session.ws_connect(
+            self._uri,
+            ssl=ssl_ctx,
+            heartbeat=None,  # firmware rejects WS pings — see module docstring
+            autoping=False,
+            headers={"Authorization": f"Basic {self._auth}"},
+        ) as ws:
+            self._ws = ws
+            _LOGGER.info("Connected to GARDENA smart Gateway at %s", self._uri)
+            # The reader must run concurrently with discovery: discovery awaits
+            # reply frames that only the reader can process.
+            reader = self._hass.async_create_background_task(
+                self._read_loop(ws), "gardena_ng_local_reader"
+            )
+            keepalive: asyncio.Task[None] | None = None
+            try:
+                await self._discover(ws)
+                self._set_connected(True)
+                keepalive = self._hass.async_create_background_task(
+                    self._keepalive(ws), "gardena_ng_local_keepalive"
+                )
+                await reader  # pump until the socket closes or errors
+            finally:
+                for task in (reader, keepalive):
+                    if task is not None:
+                        task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await task
+                self._ws = None
+
+    async def _discover(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        request = build_discovery_obj()
+        request_ids = [r.request_id for r in request.root if r.request_id is not None]
+        loop = asyncio.get_running_loop()
+        futures = {rid: loop.create_future() for rid in request_ids}
+        self._pending.update(futures)
+        await ws.send_str(request.model_dump_json())
+        try:
+            async with asyncio.timeout(DISCOVERY_TIMEOUT_SECONDS):
+                replies = await asyncio.gather(*futures.values())
+        finally:
+            for rid in request_ids:
+                self._pending.pop(rid, None)
+        self.devices = await create_devices_from_messages(IngressMessageList(list(replies)))
+        _LOGGER.info("Local discovery found %d device(s)", len(self.devices))
+        self._on_devices_updated(self.devices)
+
+    async def _read_loop(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        async for msg in ws:
+            if msg.type is aiohttp.WSMsgType.TEXT:
+                self._on_raw(msg.data)
+            elif msg.type in (
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSING,
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.ERROR,
+            ):
+                break
+
+    async def _keepalive(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """Send a cheap text `read` periodically to keep/verify the link."""
+        first = next(iter(self.devices.values()), None)
+        if first is None:
+            return
+        probe = first.build_refresh_online_status_obj
+        while not ws.closed:
+            await asyncio.sleep(KEEPALIVE_INTERVAL_SECONDS)
+            with contextlib.suppress(Exception):
+                await ws.send_str(probe.model_dump_json())
+
+    # ── message handling (transport-free, unit-testable) ──────────
+    def _on_raw(self, raw: str) -> None:
+        try:
+            messages = IngressMessageList.model_validate_json(raw)
+        except ValueError:
+            _LOGGER.debug("Ignoring non-conforming local frame: %s", raw)
+            return
+        self._handle_ingress(messages)
+
+    def _handle_ingress(self, messages: IngressMessageList) -> None:
+        """Resolve pending replies and apply events; notify owner if changed."""
+        events: list[Event] = []
+        for msg in messages:
+            if isinstance(msg, Reply) and msg.request_id in self._pending:
+                fut = self._pending.pop(msg.request_id)
+                if not fut.done():
+                    fut.set_result(msg)
+            elif isinstance(msg, ErrorMessage):
+                if msg.request_id in self._pending:
+                    fut = self._pending.pop(msg.request_id)
+                    if not fut.done():
+                        fut.set_result(_as_failed_reply(msg))
+                else:
+                    _LOGGER.debug("Local gateway error frame: %s", msg.error_message)
+            elif isinstance(msg, Event):
+                events.append(msg)
+        if self._apply_events(events):
+            self._on_devices_updated(self.devices)
+
+    def _apply_events(self, events: list[Event]) -> bool:
+        """Apply update/delete events to the local device map. Returns changed."""
+        changed = False
+        for event in events:
+            device_id = event.entity.device
+            if not device_id:
+                continue
+            if event.op == "delete" and event.entity.path.object_name is None:
+                if self.devices.pop(device_id, None) is not None:
+                    changed = True
+                continue
+            device: Any = self.devices.get(device_id)
+            if device is None:
+                continue
+            device.update_data(event)
+            changed = True
+        return changed
+
+    # ── helpers ───────────────────────────────────────────────────
+    @callback
+    def _set_connected(self, value: bool) -> None:
+        if value != self._connected:
+            self._connected = value
+            self._on_connection_change(value)
+
+    def _fail_pending(self) -> None:
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.cancel()
+        self._pending.clear()
+
+
+def _as_failed_reply(error: ErrorMessage) -> Reply:
+    """Represent an ErrorMessage as an unsuccessful Reply for the waiter."""
+    return Reply(request_id=error.request_id or "", success=False, payload=error.payload)

--- a/custom_components/gardena_smart_system_ng/local_ids.py
+++ b/custom_components/gardena_smart_system_ng/local_ids.py
@@ -1,0 +1,40 @@
+"""Mapping between local gateway device ids and cloud device serials.
+
+The local GARDENA smart Gateway identifies devices by their 24-hex-character
+SGTIN96 EPC (e.g. ``3034F8EE901EE94000001294``). The cloud API — and therefore
+every existing HA entity/device in this integration — identifies the same
+physical device by its printed serial number, zero-padded to 8 digits
+(e.g. ``00004756``).
+
+The bridge is the SGTIN96 *serial* field: decoding the local id yields the
+integer serial, which zero-padded to 8 digits equals the cloud serial. Verified
+live against three devices (Irrigation Control 4756→00004756, two Dual Water
+Controls 16257→00016257 / 17966→00017966). Decoding is done by the official
+``gardena-smart-local-api`` library, which this integration already depends on.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from gardena_smart_local_api.sgtin96 import SGTIN96Info
+
+from .const import LOCAL_SERIAL_PAD_WIDTH
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def cloud_serial_from_local_id(local_id: str) -> str | None:
+    """Return the cloud device serial for a local gateway device id.
+
+    ``local_id`` is the gateway's 24-hex-character SGTIN96 EPC. Returns the
+    zero-padded serial string used as the cloud-side device identifier, or
+    ``None`` if ``local_id`` is not a decodable SGTIN96 (in which case the
+    caller should skip the device rather than guess a mapping).
+    """
+    try:
+        info = SGTIN96Info.from_hex(local_id)
+    except ValueError as err:
+        _LOGGER.debug("Cannot decode local device id %s as SGTIN96: %s", local_id, err)
+        return None
+    return f"{info.serial:0{LOCAL_SERIAL_PAD_WIDTH}d}"

--- a/custom_components/gardena_smart_system_ng/local_translate.py
+++ b/custom_components/gardena_smart_system_ng/local_translate.py
@@ -1,0 +1,201 @@
+"""Translation between the cloud device model and the local gateway model.
+
+Two directions, both pure and unit-testable:
+
+* **Command** (cloud → local): turn a cloud command
+  ``(service_id, control_type, command, seconds)`` — exactly what the entity
+  platforms already produce for ``client.async_send_command`` — into a local
+  ``EgressMessageList`` built by the official ``gardena-smart-local-api``.
+  Returns ``None`` when the command cannot be expressed locally, so the caller
+  falls back to the proven cloud path.
+
+* **State** (local → cloud): overlay fresh local device state onto the cloud
+  ``Device`` model the entities read, so a connected local link makes state
+  update instantly and survive a cloud/internet outage.
+
+Valve identity is the one correspondence not carried by a shared id: the cloud
+addresses valves by ``service_id`` suffix (``uuid:1``…), the local library by a
+0-based ``valve_id``. We map them **positionally** — the k-th cloud valve (by
+sorted integer suffix) is the k-th local valve — which is robust to whether the
+cloud suffix is 0- or 1-based. This assumes both sides enumerate a device's
+valves in the same physical order (they do in practice); it is the single
+assumption worth re-checking against live data before trusting local control of
+a multi-valve controller.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aiogardenasmart.const import ControlType, ValveActivity
+from gardena_smart_local_api.messages import EgressMessageList
+
+from aiogardenasmart import Device as CloudDevice
+
+from .local_ids import cloud_serial_from_local_id
+
+# Cloud command verbs (see coordinator._MQTT_DISPATCH / valve.py / switch.py).
+CMD_START = "START_SECONDS_TO_OVERRIDE"
+CMD_STOP = "STOP_UNTIL_NEXT_TASK"
+
+# Cloud valve activities that mean "water is flowing" (see valve.py.is_closed).
+_WATERING_ACTIVITIES = frozenset({ValveActivity.MANUAL_WATERING, ValveActivity.SCHEDULED_WATERING})
+
+
+def index_local_devices_by_serial(local_devices: Any) -> dict[str, Any]:
+    """Map cloud serial → local device object for every decodable local device."""
+    mapping: dict[str, Any] = {}
+    for device in local_devices.values():
+        serial = cloud_serial_from_local_id(device.id)
+        if serial is not None:
+            mapping[serial] = device
+    return mapping
+
+
+def sorted_valve_service_ids(cloud_device: CloudDevice) -> list[str]:
+    """Cloud valve service_ids ordered by their integer suffix (``uuid:1`` → 1)."""
+
+    def _suffix(service_id: str) -> int:
+        tail = service_id.rsplit(":", 1)[-1]
+        return int(tail) if tail.isdigit() else -1
+
+    return sorted(cloud_device.valves, key=_suffix)
+
+
+def local_valve_position(cloud_device: CloudDevice, service_id: str) -> int | None:
+    """Positional index of a cloud valve within its device, or ``None``."""
+    ordered = sorted_valve_service_ids(cloud_device)
+    return ordered.index(service_id) if service_id in ordered else None
+
+
+def build_local_command(
+    local_device: Any,
+    cloud_device: CloudDevice,
+    service_id: str,
+    control_type: str,
+    command: str,
+    seconds: int | None,
+) -> EgressMessageList | None:
+    """Build the local egress for a cloud command, or ``None`` if not mappable."""
+    if control_type == ControlType.VALVE:
+        return _build_valve_command(local_device, cloud_device, service_id, command, seconds)
+    if control_type == ControlType.POWER_SOCKET:
+        if command == CMD_START and seconds is not None:
+            return _call(local_device, "build_enable_output_obj", seconds)
+        if command == CMD_STOP:
+            return _call(local_device, "build_disable_output_obj")
+        return None
+    if control_type == ControlType.MOWER:
+        # Local start needs an explicit duration; park maps to stop-mowing.
+        # Anything else (e.g. START_DONT_OVERRIDE) is left to the cloud path.
+        if command == CMD_START and seconds is not None:
+            return _call(local_device, "build_start_mowing_obj", seconds)
+        if command.startswith("PARK"):
+            return _call(local_device, "build_stop_mowing_obj")
+        return None
+    return None
+
+
+def _build_valve_command(
+    local_device: Any,
+    cloud_device: CloudDevice,
+    service_id: str,
+    command: str,
+    seconds: int | None,
+) -> EgressMessageList | None:
+    position = local_valve_position(cloud_device, service_id)
+    valve_ids = getattr(local_device, "valve_ids", None)
+    if position is None or not valve_ids or position >= len(valve_ids):
+        return None
+    valve_id = valve_ids[position]
+    if command == CMD_START and seconds is not None:
+        return _call(local_device, "build_open_valve_obj", valve_id, seconds)
+    if command == CMD_STOP:
+        return _call(local_device, "build_close_valve_obj", valve_id)
+    return None
+
+
+def _call(obj: Any, method: str, *args: Any) -> EgressMessageList | None:
+    """Call a local-library builder if the device supports it."""
+    builder = getattr(obj, method, None)
+    if builder is None:
+        return None
+    result: EgressMessageList = builder(*args)
+    return result
+
+
+def apply_local_state(local_device: Any, cloud_device: CloudDevice) -> bool:
+    """Overlay fresh local state onto the cloud device model. Returns changed.
+
+    Conservative by design: it only asserts the facts the local model states
+    unambiguously (link online, valve open/closed, soil sensor values) and
+    leaves richer cloud-only labels (manual vs scheduled watering) untouched
+    when local and cloud already agree on open/closed.
+    """
+    changed = False
+    changed |= _overlay_online(local_device, cloud_device)
+    changed |= _overlay_valves(local_device, cloud_device)
+    changed |= _overlay_sensor(local_device, cloud_device)
+    return changed
+
+
+def _overlay_online(local_device: Any, cloud_device: CloudDevice) -> bool:
+    online = _safe(local_device, "is_online")
+    common = cloud_device.common
+    if online is None or common is None:
+        return False
+    desired = "ONLINE" if online else "OFFLINE"
+    if common.rf_link_state != desired:
+        common.rf_link_state = desired
+        return True
+    return False
+
+
+def _overlay_valves(local_device: Any, cloud_device: CloudDevice) -> bool:
+    valve_ids = getattr(local_device, "valve_ids", None)
+    if not valve_ids or not cloud_device.valves:
+        return False
+    changed = False
+    for position, service_id in enumerate(sorted_valve_service_ids(cloud_device)):
+        if position >= len(valve_ids):
+            break
+        is_open = _safe(local_device, "is_valve_open", valve_ids[position])
+        if is_open is None:
+            continue
+        valve = cloud_device.valves[service_id]
+        if is_open and valve.activity == ValveActivity.CLOSED:
+            valve.activity = ValveActivity.MANUAL_WATERING
+            changed = True
+        elif not is_open and valve.activity in _WATERING_ACTIVITIES:
+            valve.activity = ValveActivity.CLOSED
+            valve.duration = 0
+            valve.duration_timestamp = None
+            changed = True
+    return changed
+
+
+def _overlay_sensor(local_device: Any, cloud_device: CloudDevice) -> bool:
+    sensor = cloud_device.sensor
+    if sensor is None:
+        return False
+    changed = False
+    moisture = _prop(local_device, "soil_moisture")
+    if moisture is not None and sensor.soil_humidity != moisture:
+        sensor.soil_humidity = moisture
+        changed = True
+    temperature = _prop(local_device, "temperature")
+    if temperature is not None and sensor.soil_temperature != temperature:
+        sensor.soil_temperature = float(temperature)
+        changed = True
+    return changed
+
+
+def _safe(obj: Any, method: str, *args: Any) -> Any:
+    """Call an accessor method, returning None if the device lacks it."""
+    accessor = getattr(obj, method, None)
+    return accessor(*args) if callable(accessor) else None
+
+
+def _prop(obj: Any, name: str) -> Any:
+    """Read a property, returning None if the device lacks it."""
+    return getattr(obj, name, None)

--- a/custom_components/gardena_smart_system_ng/manifest.json
+++ b/custom_components/gardena_smart_system_ng/manifest.json
@@ -8,9 +8,9 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/kayloehmann/ha-gardena-smart-system/issues",
-  "loggers": ["aiogardenasmart"],
+  "loggers": ["aiogardenasmart", "gardena_smart_local_api"],
   "quality_scale": "platinum",
-  "requirements": ["aiogardenasmart==0.1.9"],
+  "requirements": ["aiogardenasmart==0.1.9", "gardena-smart-local-api==0.0.11"],
   "single_config_entry": false,
   "version": "2.0.5"
 }

--- a/custom_components/gardena_smart_system_ng/sensor.py
+++ b/custom_components/gardena_smart_system_ng/sensor.py
@@ -30,7 +30,7 @@ from aiogardenasmart import Device
 
 from . import GardenaConfigEntry
 from .base_coordinator import BaseSmartSystemCoordinator
-from .const import API_TYPE_AUTOMOWER, CONF_API_TYPE, DOMAIN
+from .const import API_TYPE_AUTOMOWER, CONF_API_TYPE, DOMAIN, OPT_LOCAL_ENABLE
 from .coordinator import GardenaCoordinator
 from .entity import GardenaEntity, resolve_zone_placeholder
 
@@ -286,6 +286,15 @@ async def async_setup_entry(
                 if vs_key not in known_keys:
                     known_keys.add(vs_key)
                     new_entities.append(GardenaValveSetErrorSensor(coordinator, device))
+            # Command-source diagnostic (local vs cloud) — only with local access
+            # enabled and only for devices that can actually receive commands.
+            if entry.options.get(OPT_LOCAL_ENABLE) and (
+                device.valves or device.power_socket is not None or device.mower is not None
+            ):
+                cs_key = (device.device_id, "command_source")
+                if cs_key not in known_keys:
+                    known_keys.add(cs_key)
+                    new_entities.append(GardenaCommandSourceSensor(coordinator, device))
         if new_entities:
             async_add_entities(new_entities)
 
@@ -301,6 +310,24 @@ async def async_setup_entry(
             HubApiBudgetRemainingSensor(coordinator, entry),
         ]
     )
+
+
+class GardenaCommandSourceSensor(GardenaEntity, SensorEntity):
+    """Diagnostic sensor: which route carried this device's last command."""
+
+    _attr_translation_key = "command_source"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: GardenaCoordinator, device: Device) -> None:
+        """Initialize the command-source sensor."""
+        super().__init__(coordinator, device, "command_source")
+        self._attr_options = ["local", "cloud"]
+
+    @property
+    def native_value(self) -> str | None:
+        """Return 'local', 'cloud', or None if no command has been sent yet."""
+        return self.coordinator.last_command_source(self._device_id)
 
 
 class GardenaSensorEntity(GardenaEntity, SensorEntity):

--- a/custom_components/gardena_smart_system_ng/strings.json
+++ b/custom_components/gardena_smart_system_ng/strings.json
@@ -77,7 +77,11 @@
           "mqtt_enable": "Enable MQTT bridge",
           "mqtt_topic_prefix": "MQTT topic prefix",
           "mqtt_publish_states": "Publish device states to MQTT",
-          "mqtt_subscribe_commands": "Accept commands via MQTT"
+          "mqtt_subscribe_commands": "Accept commands via MQTT",
+          "local_enable": "Enable local gateway access",
+          "local_host": "Gateway host or IP",
+          "local_password": "Gateway password",
+          "local_port": "Gateway port"
         },
         "data_description": {
           "default_watering_minutes": "Duration in minutes when opening a valve without specifying a duration (1-1440).",
@@ -87,13 +91,24 @@
           "mqtt_enable": "Mirror device states to a local MQTT broker and optionally accept commands. Requires the MQTT integration to be configured.",
           "mqtt_topic_prefix": "Base topic for all MQTT messages (e.g. 'gardena' → gardena/{device_id}/state).",
           "mqtt_publish_states": "Publish full device state as JSON on every update (WebSocket push or poll).",
-          "mqtt_subscribe_commands": "Subscribe to {prefix}/{device_id}/command for inbound commands (start_watering, stop_watering, turn_on, turn_off, park, resume)."
+          "mqtt_subscribe_commands": "Subscribe to {prefix}/{device_id}/command for inbound commands (start_watering, stop_watering, turn_on, turn_off, park, resume).",
+          "local_enable": "Talk to the GARDENA smart Gateway directly over the LAN. Local state takes precedence over the cloud and commands are sent locally first (cloud is the fallback). The gateway's websocketd service must be enabled once via shell — see the documentation.",
+          "local_host": "Hostname or IP of the gateway (e.g. 10.0.0.5 or GARDENA-xxxxxx.local). Leave empty to disable.",
+          "local_password": "The first 8 characters of the gateway's device id (printed on the underside).",
+          "local_port": "WebSocket port of the gateway (default 8443)."
         }
       }
     }
   },
   "entity": {
     "sensor": {
+      "command_source": {
+        "name": "Last command via",
+        "state": {
+          "local": "Local",
+          "cloud": "Cloud"
+        }
+      },
       "battery_level": {
         "name": "Battery"
       },
@@ -275,6 +290,9 @@
       },
       "hub_websocket_connected": {
         "name": "WebSocket connected"
+      },
+      "hub_local_connected": {
+        "name": "Local gateway connected"
       }
     },
     "switch": {

--- a/custom_components/gardena_smart_system_ng/switch.py
+++ b/custom_components/gardena_smart_system_ng/switch.py
@@ -156,7 +156,7 @@ class GardenaPowerSocketEntity(GardenaEntity, SwitchEntity):
                 translation_key="device_unavailable",
             )
         await self._async_execute_command(
-            self.coordinator.client.async_send_command,
+            self.coordinator.async_send_command,
             service_id=device.power_socket.service_id,
             control_type=ControlType.POWER_SOCKET,
             command=command,

--- a/custom_components/gardena_smart_system_ng/translations/de.json
+++ b/custom_components/gardena_smart_system_ng/translations/de.json
@@ -76,7 +76,11 @@
           "mqtt_enable": "MQTT-Bridge aktivieren",
           "mqtt_topic_prefix": "MQTT-Topic-Präfix",
           "mqtt_publish_states": "Gerätezustände per MQTT veröffentlichen",
-          "mqtt_subscribe_commands": "Befehle per MQTT empfangen"
+          "mqtt_subscribe_commands": "Befehle per MQTT empfangen",
+          "local_enable": "Lokalen Gateway-Zugriff aktivieren",
+          "local_host": "Gateway-Host oder -IP",
+          "local_password": "Gateway-Passwort",
+          "local_port": "Gateway-Port"
         },
         "data_description": {
           "default_watering_minutes": "Dauer in Minuten beim Öffnen eines Ventils ohne Angabe einer Dauer (1–1440).",
@@ -85,13 +89,24 @@
           "mqtt_enable": "Spiegelt Gerätezustände auf einen lokalen MQTT-Broker und empfängt optional Befehle. Die MQTT-Integration muss konfiguriert sein.",
           "mqtt_topic_prefix": "Basis-Topic für alle MQTT-Nachrichten (z.B. ‘gardena’ → gardena/DEVICE_ID/state).",
           "mqtt_publish_states": "Veröffentlicht den vollständigen Gerätezustand als JSON bei jeder Aktualisierung (WebSocket-Push oder Abfrage).",
-          "mqtt_subscribe_commands": "Abonniert PREFIX/DEVICE_ID/command für eingehende Befehle (start_watering, stop_watering, turn_on, turn_off, park, resume)."
+          "mqtt_subscribe_commands": "Abonniert PREFIX/DEVICE_ID/command für eingehende Befehle (start_watering, stop_watering, turn_on, turn_off, park, resume).",
+          "local_enable": "Direkt mit dem GARDENA smart Gateway über das LAN kommunizieren. Der lokale Zustand hat Vorrang vor der Cloud, und Befehle werden zuerst lokal gesendet (Cloud als Fallback). Der websocketd-Dienst des Gateways muss einmalig per Shell aktiviert werden — siehe Dokumentation.",
+          "local_host": "Hostname oder IP des Gateways (z.B. 10.0.0.5 oder GARDENA-xxxxxx.local). Leer lassen zum Deaktivieren.",
+          "local_password": "Die ersten 8 Zeichen der Geräte-ID des Gateways (auf der Unterseite aufgedruckt).",
+          "local_port": "WebSocket-Port des Gateways (Standard 8443)."
         }
       }
     }
   },
   "entity": {
     "sensor": {
+      "command_source": {
+        "name": "Letzter Befehl über",
+        "state": {
+          "local": "Lokal",
+          "cloud": "Cloud"
+        }
+      },
       "battery_level": {
         "name": "Akku"
       },
@@ -297,6 +312,9 @@
       },
       "hub_websocket_connected": {
         "name": "WebSocket verbunden"
+      },
+      "hub_local_connected": {
+        "name": "Lokales Gateway verbunden"
       }
     },
     "switch": {

--- a/custom_components/gardena_smart_system_ng/translations/en.json
+++ b/custom_components/gardena_smart_system_ng/translations/en.json
@@ -77,7 +77,11 @@
           "mqtt_enable": "Enable MQTT bridge",
           "mqtt_topic_prefix": "MQTT topic prefix",
           "mqtt_publish_states": "Publish device states to MQTT",
-          "mqtt_subscribe_commands": "Accept commands via MQTT"
+          "mqtt_subscribe_commands": "Accept commands via MQTT",
+          "local_enable": "Enable local gateway access",
+          "local_host": "Gateway host or IP",
+          "local_password": "Gateway password",
+          "local_port": "Gateway port"
         },
         "data_description": {
           "default_watering_minutes": "Duration in minutes when opening a valve without specifying a duration (1-1440).",
@@ -87,13 +91,24 @@
           "mqtt_enable": "Mirror device states to a local MQTT broker and optionally accept commands. Requires the MQTT integration to be configured.",
           "mqtt_topic_prefix": "Base topic for all MQTT messages (e.g. 'gardena' → gardena/DEVICE_ID/state).",
           "mqtt_publish_states": "Publish full device state as JSON on every update (WebSocket push or poll).",
-          "mqtt_subscribe_commands": "Subscribe to PREFIX/DEVICE_ID/command for inbound commands (start_watering, stop_watering, turn_on, turn_off, park, resume)."
+          "mqtt_subscribe_commands": "Subscribe to PREFIX/DEVICE_ID/command for inbound commands (start_watering, stop_watering, turn_on, turn_off, park, resume).",
+          "local_enable": "Talk to the GARDENA smart Gateway directly over the LAN. Local state takes precedence over the cloud and commands are sent locally first (cloud is the fallback). The gateway's websocketd service must be enabled once via shell — see the documentation.",
+          "local_host": "Hostname or IP of the gateway (e.g. 10.0.0.5 or GARDENA-xxxxxx.local). Leave empty to disable.",
+          "local_password": "The first 8 characters of the gateway's device id (printed on the underside).",
+          "local_port": "WebSocket port of the gateway (default 8443)."
         }
       }
     }
   },
   "entity": {
     "sensor": {
+      "command_source": {
+        "name": "Last command via",
+        "state": {
+          "local": "Local",
+          "cloud": "Cloud"
+        }
+      },
       "battery_level": {
         "name": "Battery"
       },
@@ -299,6 +314,9 @@
       },
       "hub_websocket_connected": {
         "name": "WebSocket connected"
+      },
+      "hub_local_connected": {
+        "name": "Local gateway connected"
       }
     },
     "switch": {

--- a/custom_components/gardena_smart_system_ng/valve.py
+++ b/custom_components/gardena_smart_system_ng/valve.py
@@ -199,7 +199,7 @@ class GardenaValveEntity(GardenaEntity, ValveEntity):
                 translation_key="device_unavailable",
             )
         await self._async_execute_command(
-            self.coordinator.client.async_send_command,
+            self.coordinator.async_send_command,
             service_id=self._service_id,
             control_type=ControlType.VALVE,
             command=command,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,15 @@ warn_unreachable = true
 module = "tests.*"
 disallow_untyped_defs = false
 
+# The official `gardena-smart-local-api` (GARDENA GmbH, used for local gateway
+# access) does not yet ship a PEP 561 `py.typed` marker, so mypy cannot import
+# its types. We isolate that untyped boundary here; every value crossing it is
+# re-typed in our own `local_ids`/`local_channel` wrappers, which remain fully
+# strict-checked. TODO: drop this once upstream ships py.typed (contribute it).
+[[tool.mypy.overrides]]
+module = "gardena_smart_local_api.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/tests/components/gardena_smart_system_ng/test_automower_coverage.py
+++ b/tests/components/gardena_smart_system_ng/test_automower_coverage.py
@@ -1,0 +1,132 @@
+"""Coverage for Automower entity device-missing guards and the confirmation wait."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:
+    from pytest_homeassistant_custom_component.common import (
+        MockConfigEntry,  # type: ignore[no-redef]
+    )
+
+from custom_components.gardena_smart_system_ng import automower_entity as automower_entity_mod
+from custom_components.gardena_smart_system_ng.automower_button import (
+    AutomowerConfirmErrorButton,
+)
+from custom_components.gardena_smart_system_ng.automower_coordinator import (
+    AutomowerCoordinator,
+)
+from custom_components.gardena_smart_system_ng.automower_lawn_mower import (
+    AutomowerLawnMowerEntity,
+)
+from custom_components.gardena_smart_system_ng.automower_number import (
+    AutomowerScheduleOverrideEntity,
+)
+from custom_components.gardena_smart_system_ng.automower_select import (
+    AutomowerHeadlightSelect,
+)
+from custom_components.gardena_smart_system_ng.automower_select import (
+    async_setup_entry as select_setup,
+)
+from custom_components.gardena_smart_system_ng.automower_switch import (
+    AutomowerWorkAreaSwitch,
+)
+from custom_components.gardena_smart_system_ng.const import (
+    API_TYPE_AUTOMOWER,
+    CONF_API_TYPE,
+    DOMAIN,
+)
+
+from .conftest import ENTRY_DATA
+from .test_automower import make_mock_automower_device
+
+
+@pytest.fixture
+async def coord(hass: HomeAssistant) -> AutomowerCoordinator:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**ENTRY_DATA, CONF_API_TYPE: API_TYPE_AUTOMOWER},
+        title="Mower",
+    )
+    entry.add_to_hass(hass)
+    coordinator = AutomowerCoordinator(hass, entry, async_get_clientsession(hass))
+    coordinator._auth = AsyncMock()
+    return coordinator
+
+
+async def test_button_press_without_device_raises(coord: AutomowerCoordinator) -> None:
+    device = make_mock_automower_device(is_error_confirmable=True, can_confirm_error=True)
+    entity = AutomowerConfirmErrorButton(coord, device)
+    coord.data = {}
+    with pytest.raises(HomeAssistantError):
+        await entity.async_press()
+
+
+async def test_number_override_none_and_raise(coord: AutomowerCoordinator) -> None:
+    device = make_mock_automower_device()
+    entity = AutomowerScheduleOverrideEntity(coord, device)
+    coord.data = {}
+    assert entity.native_value is None
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(30)
+
+
+async def test_select_none_and_raise(coord: AutomowerCoordinator) -> None:
+    device = make_mock_automower_device()
+    entity = AutomowerHeadlightSelect(coord, device)
+    coord.data = {}
+    assert entity.current_option is None
+    with pytest.raises(HomeAssistantError):
+        await entity.async_select_option("always_on")
+
+
+async def test_select_setup_skips_non_automower(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, title="Garden")  # no automower type
+    entry.add_to_hass(hass)
+    added = MagicMock()
+    await select_setup(hass, entry, added)
+    added.assert_not_called()
+
+
+async def test_work_area_switch_none_and_raise(coord: AutomowerCoordinator) -> None:
+    device = make_mock_automower_device(has_work_areas=True)
+    work_area_id = next(iter(device.work_areas), 0)
+    entity = AutomowerWorkAreaSwitch(coord, device, work_area_id)
+    coord.data = {}
+    assert entity.is_on is None
+    with pytest.raises(HomeAssistantError):
+        await entity.async_turn_on()
+
+
+async def test_lawn_mower_check_without_device(coord: AutomowerCoordinator) -> None:
+    device = make_mock_automower_device()
+    entity = AutomowerLawnMowerEntity(coord, device)
+    check = entity._make_expected_state_check("mowing")
+    assert check is not None
+    coord.data = {}
+    assert check() is False
+
+
+async def test_wait_for_expected_state_confirms(
+    coord: AutomowerCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(automower_entity_mod, "COMMAND_POLL_AFTER_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(automower_entity_mod, "COMMAND_POLL_INTERVAL_SECONDS", 0.001)
+    device = make_mock_automower_device()
+    entity = AutomowerLawnMowerEntity(coord, device)
+    coord._ws_push_at[entity._mower_id] = 100.0
+
+    calls: list[int] = []
+
+    def check() -> bool:
+        calls.append(1)
+        return len(calls) > 1
+
+    assert await entity._async_wait_for_expected_state(check, 0.0) is True

--- a/tests/components/gardena_smart_system_ng/test_base_coordinator_coverage.py
+++ b/tests/components/gardena_smart_system_ng/test_base_coordinator_coverage.py
@@ -19,6 +19,7 @@ except ImportError:
     )
 
 from aiogardenasmart import GardenaConnectionError
+from custom_components.gardena_smart_system_ng import base_coordinator as base_coordinator_mod
 from custom_components.gardena_smart_system_ng.base_coordinator import (
     BaseSmartSystemCoordinator,
     RateLimitState,
@@ -27,7 +28,6 @@ from custom_components.gardena_smart_system_ng.base_coordinator import (
 from custom_components.gardena_smart_system_ng.const import (
     DOMAIN,
     OPT_MQTT_ENABLE,
-    WS_WATCHDOG_TIMEOUT_SECONDS,
 )
 from custom_components.gardena_smart_system_ng.coordinator import GardenaCoordinator
 
@@ -184,8 +184,14 @@ async def test_watchdog_reconnects_on_silence(
     coord: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     coord._ws_connected = True
+    # Shrink the timeout so the test is independent of the machine's uptime:
+    # last_message_time must stay positive (a real monotonic marker) while the
+    # silence still exceeds the timeout. A large fixed timeout would force a
+    # negative marker on freshly-booted CI runners and hit the "no messages
+    # yet" guard instead of the reconnect path.
+    monkeypatch.setattr(base_coordinator_mod, "WS_WATCHDOG_TIMEOUT_SECONDS", 1)
     ws = MagicMock()
-    ws.last_message_time = time.monotonic() - (WS_WATCHDOG_TIMEOUT_SECONDS + 5)
+    ws.last_message_time = time.monotonic() - 5  # positive marker, 5s of silence
     ws.async_disconnect = AsyncMock(side_effect=aiohttp.ClientError("gone"))
     coord._ws = ws
     scheduler = MagicMock()

--- a/tests/components/gardena_smart_system_ng/test_base_coordinator_coverage.py
+++ b/tests/components/gardena_smart_system_ng/test_base_coordinator_coverage.py
@@ -1,0 +1,248 @@
+"""Targeted coverage for base_coordinator edge paths (rate-limit, WS, MQTT)."""
+
+from __future__ import annotations
+
+import time
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:
+    from pytest_homeassistant_custom_component.common import (
+        MockConfigEntry,  # type: ignore[no-redef]
+    )
+
+from aiogardenasmart import GardenaConnectionError
+from custom_components.gardena_smart_system_ng.base_coordinator import (
+    BaseSmartSystemCoordinator,
+    RateLimitState,
+    _parse_iso_utc,
+)
+from custom_components.gardena_smart_system_ng.const import (
+    DOMAIN,
+    OPT_MQTT_ENABLE,
+    WS_WATCHDOG_TIMEOUT_SECONDS,
+)
+from custom_components.gardena_smart_system_ng.coordinator import GardenaCoordinator
+
+from .conftest import ENTRY_DATA, make_mock_device
+
+
+@pytest.fixture
+async def coord(hass: HomeAssistant) -> GardenaCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, title="My Garden")
+    entry.add_to_hass(hass)
+    c = GardenaCoordinator(hass, entry, async_get_clientsession(hass))
+    c._auth = AsyncMock()
+    return c
+
+
+# ── RateLimitState / helpers ──────────────────────────────────────────
+
+
+def test_parse_iso_utc_variants() -> None:
+    assert _parse_iso_utc("") is None
+    assert _parse_iso_utc("not-a-timestamp") is None  # malformed → None
+    assert _parse_iso_utc("2020-01-01T00:00:00+00:00") is not None
+
+
+def _state() -> RateLimitState:
+    store = MagicMock()
+    store.async_delay_save = MagicMock()
+    store.async_save = AsyncMock()
+    return RateLimitState(store)
+
+
+def test_rate_limit_ladder_and_last_429() -> None:
+    state = _state()
+    assert state.last_429_at is None
+    _state().reset_rate_limits()  # already clean → early return
+    state.record_rate_limit()
+    assert state.last_429_at is not None
+    state.reset_rate_limits()
+    assert state.rate_limit_hits == 0
+
+
+def test_handshake_and_kill_switch() -> None:
+    state = _state()
+    state.clear_handshake_denials()  # already clean → early return
+    state.record_handshake_denial()
+    state.activate_kill_switch(timedelta(hours=1))
+    assert state.is_kill_switch_active()
+    state.activate_kill_switch(timedelta(seconds=-1))  # already expired
+    assert state.kill_switch_remaining() is None
+    state.clear_handshake_denials()
+    assert state.ws_handshake_denials == 0
+
+
+async def test_rate_limit_state_async_reset() -> None:
+    store = MagicMock()
+    store.async_delay_save = MagicMock()
+    store.async_save = AsyncMock()
+    state = RateLimitState(store)
+    state.record_rate_limit()
+    await state.async_reset()
+    store.async_save.assert_awaited_once()
+    assert state.rate_limit_hits == 0
+
+
+# ── WebSocket start / device update ───────────────────────────────────
+
+
+async def test_start_websocket_skips_when_already_connected(
+    coord: GardenaCoordinator,
+) -> None:
+    coord._ws_connected = True
+    await coord._async_start_websocket({})  # double-checks under lock and returns
+
+
+async def test_ws_url_connection_error_records_failure(
+    coord: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    coord._ws_connected = False
+
+    async def raise_conn(_devices: object) -> str:
+        raise GardenaConnectionError("down")
+
+    monkeypatch.setattr(coord, "_async_get_ws_url", raise_conn)
+    recorder = MagicMock()
+    monkeypatch.setattr(coord, "_record_ws_failure", recorder)
+    await coord._async_start_websocket_locked({"d": make_mock_device()})
+    recorder.assert_called_once()
+
+
+async def test_on_device_update_publishes_to_mqtt(
+    coord: GardenaCoordinator, hass: HomeAssistant
+) -> None:
+    bridge = MagicMock()
+    bridge.is_active = True
+    bridge.async_publish_device_state = AsyncMock()
+    coord._mqtt_bridge = bridge
+    coord.data = {}
+    device = make_mock_device()
+    coord._on_device_update(device.device_id, device)
+    await hass.async_block_till_done()
+    bridge.async_publish_device_state.assert_called_once()
+
+
+async def test_update_data_publishes_all_when_bridge_active(
+    coord: GardenaCoordinator, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    devices = {d.device_id: d for d in [make_mock_device()]}
+
+    async def fetch() -> dict:
+        return devices
+
+    monkeypatch.setattr(coord, "_async_fetch_devices", fetch)
+    coord._ws_connected = True  # skip WS (re)start
+    bridge = MagicMock()
+    bridge.is_active = True
+    bridge.async_publish_all_devices = AsyncMock()
+    coord._mqtt_bridge = bridge
+
+    await coord._async_update_data()
+    await hass.async_block_till_done()
+    bridge.async_publish_all_devices.assert_called_once()
+
+
+# ── Reconnect loop / watchdog / session timer ─────────────────────────
+
+
+async def test_reconnect_loop_stops_when_connected(
+    coord: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(coord, "_WS_RECONNECT_DELAYS", (0.001,))
+    coord._ws_connected = True
+    await coord._async_ws_reconnect_loop()
+
+
+async def test_reconnect_loop_aborts_on_kill_switch(
+    coord: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(coord, "_WS_RECONNECT_DELAYS", (0.001,))
+    coord._ws_connected = False
+    coord._ws_cooldown_until = 0.0
+    coord._rate_limit_state.activate_kill_switch(timedelta(hours=1))
+    await coord._async_ws_reconnect_loop()
+
+
+async def test_watchdog_returns_without_messages(coord: GardenaCoordinator) -> None:
+    coord._ws_connected = True
+    ws = MagicMock()
+    ws.last_message_time = 0
+    coord._ws = ws
+    await coord._async_ws_watchdog_check()
+
+
+async def test_watchdog_reconnects_on_silence(
+    coord: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    coord._ws_connected = True
+    ws = MagicMock()
+    ws.last_message_time = time.monotonic() - (WS_WATCHDOG_TIMEOUT_SECONDS + 5)
+    ws.async_disconnect = AsyncMock(side_effect=aiohttp.ClientError("gone"))
+    coord._ws = ws
+    scheduler = MagicMock()
+    monkeypatch.setattr(coord, "_schedule_ws_reconnect", scheduler)
+    await coord._async_ws_watchdog_check()
+    scheduler.assert_called_once()
+    assert coord._ws is None
+
+
+async def test_session_expired_noop_when_disconnected(
+    coord: GardenaCoordinator,
+) -> None:
+    coord._ws_connected = False
+    await coord._async_ws_session_expired()
+
+
+async def test_session_expired_reconnects(
+    coord: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    coord._ws_connected = True
+    ws = MagicMock()
+    ws.async_disconnect = AsyncMock(side_effect=aiohttp.ClientError("gone"))
+    coord._ws = ws
+    scheduler = MagicMock()
+    monkeypatch.setattr(coord, "_schedule_ws_reconnect", scheduler)
+    await coord._async_ws_session_expired()
+    scheduler.assert_called_once()
+    assert coord._ws is None
+
+
+# ── MQTT bridge lifecycle ─────────────────────────────────────────────
+
+
+async def test_start_mqtt_bridge_creates_bridge(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=ENTRY_DATA, options={OPT_MQTT_ENABLE: True}, title="My Garden"
+    )
+    entry.add_to_hass(hass)
+    coord = GardenaCoordinator(hass, entry, async_get_clientsession(hass))
+    fake_bridge = MagicMock()
+    fake_bridge.async_start = AsyncMock(return_value=True)
+    with patch(
+        "custom_components.gardena_smart_system_ng.mqtt_bridge.MqttBridge",
+        return_value=fake_bridge,
+    ):
+        await coord._async_start_mqtt_bridge()
+    assert coord._mqtt_bridge is fake_bridge
+
+
+async def test_base_mqtt_command_handler_logs(coord: GardenaCoordinator) -> None:
+    # The base handler is a no-op logger (GardenaCoordinator overrides it).
+    await BaseSmartSystemCoordinator._async_handle_mqtt_command(coord, "d", {"action": "x"})
+
+
+async def test_shutdown_stops_mqtt_bridge(coord: GardenaCoordinator) -> None:
+    bridge = MagicMock()
+    bridge.async_stop = AsyncMock()
+    coord._mqtt_bridge = bridge
+    await coord.async_shutdown()
+    bridge.async_stop.assert_awaited_once()

--- a/tests/components/gardena_smart_system_ng/test_config_flow_coverage.py
+++ b/tests/components/gardena_smart_system_ng/test_config_flow_coverage.py
@@ -1,0 +1,52 @@
+"""Coverage for the credential-test token-revocation error paths."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from custom_components.gardena_smart_system_ng.config_flow import (
+    GardenaSmartSystemConfigFlow,
+)
+
+_CF = "custom_components.gardena_smart_system_ng.config_flow"
+
+
+async def test_gardena_credential_test_swallows_revoke_error(
+    hass: HomeAssistant,
+) -> None:
+    auth = MagicMock()
+    auth.async_revoke_token = AsyncMock(side_effect=aiohttp.ClientError("no net"))
+    location = MagicMock(location_id="loc-1")
+    location.name = "Garden"  # `name=` is a reserved MagicMock kwarg, set it explicitly
+    client = MagicMock()
+    client.async_get_locations = AsyncMock(return_value=[location])
+    with (
+        patch(f"{_CF}.GardenaAuth", return_value=auth),
+        patch(f"{_CF}.GardenaClient", return_value=client),
+    ):
+        locations, error = await GardenaSmartSystemConfigFlow._async_test_gardena(
+            async_get_clientsession(hass), "id", "secret"
+        )
+    assert error == ""  # revoke failure is logged, not raised
+    assert locations == [{"id": "loc-1", "name": "Garden"}]
+
+
+async def test_automower_credential_test_swallows_revoke_error(
+    hass: HomeAssistant,
+) -> None:
+    auth = MagicMock()
+    auth.async_revoke_token = AsyncMock(side_effect=aiohttp.ClientError("no net"))
+    client = MagicMock()
+    client.async_get_mowers = AsyncMock(return_value=[])
+    with (
+        patch(f"{_CF}.GardenaAuth", return_value=auth),
+        patch("aioautomower.AutomowerClient", return_value=client),
+    ):
+        error = await GardenaSmartSystemConfigFlow._async_test_automower(
+            async_get_clientsession(hass), "id", "secret"
+        )
+    assert error == ""  # revoke failure is logged, not raised

--- a/tests/components/gardena_smart_system_ng/test_coordinator_local.py
+++ b/tests/components/gardena_smart_system_ng/test_coordinator_local.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 try:
@@ -16,14 +17,19 @@ except ImportError:
         MockConfigEntry,  # type: ignore[no-redef]
     )
 
+from custom_components.gardena_smart_system_ng.binary_sensor import HubLocalConnectionSensor
 from custom_components.gardena_smart_system_ng.const import (
     DOMAIN,
     OPT_LOCAL_ENABLE,
     OPT_LOCAL_HOST,
 )
 from custom_components.gardena_smart_system_ng.coordinator import GardenaCoordinator
+from custom_components.gardena_smart_system_ng.sensor import (
+    GardenaCommandSourceSensor,
+    _hub_device_info,
+)
 
-from .conftest import ENTRY_DATA
+from .conftest import ENTRY_DATA, make_mock_device
 
 # A real SGTIN96 id that decodes to serial 00004756 (see local_ids tests).
 LOCAL_ID = "3034F8EE901EE94000001294"
@@ -163,6 +169,59 @@ async def test_shutdown_stops_local_channel(coordinator: GardenaCoordinator) -> 
     assert coordinator._local_channel is None
 
 
+async def test_command_cloud_when_local_command_unmappable(
+    coordinator: GardenaCoordinator,
+) -> None:
+    coordinator._local_channel = FakeChannel(connected=True)  # type: ignore[assignment]
+    # Local device matches, but START_DONT_OVERRIDE has no local equivalent.
+    await coordinator.async_send_command("dev-uuid:1", "VALVE_CONTROL", "START_DONT_OVERRIDE")
+    coordinator._client.async_send_command.assert_called_once()
+    assert coordinator.last_command_source("dev-uuid") == "cloud"
+
+
+async def test_command_cloud_when_device_not_in_data(
+    coordinator: GardenaCoordinator,
+) -> None:
+    coordinator._local_channel = FakeChannel(connected=True)  # type: ignore[assignment]
+    await coordinator.async_send_command("other-uuid:1", "VALVE_CONTROL", "STOP_UNTIL_NEXT_TASK")
+    coordinator._client.async_send_command.assert_called_once()
+    assert coordinator.last_command_source("other-uuid") == "cloud"
+
+
+def test_client_property_returns_rest_client(coordinator: GardenaCoordinator) -> None:
+    assert coordinator.client is coordinator._client
+
+
+async def test_overlay_noop_without_data(coordinator: GardenaCoordinator) -> None:
+    coordinator.data = None
+    coordinator._on_local_devices_updated({LOCAL_ID: FakeLocalDevice()})  # no error, no push
+
+
+async def test_set_local_connected_notifies_listeners(
+    coordinator: GardenaCoordinator,
+) -> None:
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+    coordinator._set_local_connected(True)
+    assert coordinator.local_connected is True
+    listener.assert_called()
+
+
+def test_local_connection_binary_sensor(coordinator: GardenaCoordinator) -> None:
+    sensor = HubLocalConnectionSensor(coordinator, coordinator.config_entry, _hub_device_info)
+    assert sensor.is_on is False
+    coordinator._local_connected = True
+    assert sensor.is_on is True
+
+
+def test_command_source_sensor(coordinator: GardenaCoordinator) -> None:
+    device = coordinator.data["dev-uuid"]
+    sensor = GardenaCommandSourceSensor(coordinator, device)
+    assert sensor.native_value is None
+    coordinator._last_command_source["dev-uuid"] = "local"
+    assert sensor.native_value == "local"
+
+
 async def test_ensure_channel_starts_and_stops_with_options(
     hass: HomeAssistant,
 ) -> None:
@@ -188,3 +247,46 @@ async def test_ensure_channel_starts_and_stops_with_options(
         await coord._async_ensure_local_channel()
         fake.async_stop.assert_awaited_once()
         assert coord._local_channel is None
+
+
+async def test_local_entities_created_on_setup(hass: HomeAssistant) -> None:
+    """With local access enabled, the local-status and command-source entities exist."""
+    device = make_mock_device(valve_count=1, has_sensor=False)  # a controllable device
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=ENTRY_DATA,
+        options={OPT_LOCAL_ENABLE: True, OPT_LOCAL_HOST: "10.0.0.9"},
+        title="My Garden",
+    )
+    fake_channel = MagicMock()
+    fake_channel.async_start = AsyncMock()
+    fake_channel.async_stop = AsyncMock()
+    fake_channel.connected = False
+    fake_channel.devices = {}
+
+    p_client = "custom_components.gardena_smart_system_ng.coordinator.GardenaClient"
+    p_auth = "custom_components.gardena_smart_system_ng.coordinator.GardenaAuth"
+    p_ws = "custom_components.gardena_smart_system_ng.coordinator.GardenaWebSocket"
+    with (
+        patch(p_client) as client_cls,
+        patch(p_auth, return_value=AsyncMock()),
+        patch(p_ws) as ws_cls,
+        patch(_PATCH_LOCAL_CHANNEL, return_value=fake_channel),
+    ):
+        client = AsyncMock()
+        client.async_get_devices = AsyncMock(return_value={device.device_id: device})
+        client.async_get_websocket_url = AsyncMock(return_value="wss://test")
+        client_cls.return_value = client
+        ws = AsyncMock()
+        ws.async_connect = AsyncMock()
+        ws.async_disconnect = AsyncMock()
+        ws_cls.return_value = ws
+
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    unique_ids = {e.unique_id for e in er.async_entries_for_config_entry(registry, entry.entry_id)}
+    assert any(u.endswith("_command_source") for u in unique_ids)
+    assert f"hub_{entry.entry_id}_local_connected" in unique_ids

--- a/tests/components/gardena_smart_system_ng/test_coordinator_local.py
+++ b/tests/components/gardena_smart_system_ng/test_coordinator_local.py
@@ -1,0 +1,190 @@
+"""Tests for the local-gateway wiring in GardenaCoordinator."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:
+    from pytest_homeassistant_custom_component.common import (
+        MockConfigEntry,  # type: ignore[no-redef]
+    )
+
+from custom_components.gardena_smart_system_ng.const import (
+    DOMAIN,
+    OPT_LOCAL_ENABLE,
+    OPT_LOCAL_HOST,
+)
+from custom_components.gardena_smart_system_ng.coordinator import GardenaCoordinator
+
+from .conftest import ENTRY_DATA
+
+# A real SGTIN96 id that decodes to serial 00004756 (see local_ids tests).
+LOCAL_ID = "3034F8EE901EE94000001294"
+CLOUD_SERIAL = "00004756"
+
+_PATCH_LOCAL_CHANNEL = "custom_components.gardena_smart_system_ng.coordinator.GardenaLocalChannel"
+
+
+class FakeLocalDevice:
+    def __init__(self) -> None:
+        self.id = LOCAL_ID
+        self.valve_ids = [0]
+
+    def build_open_valve_obj(self, valve_id: int, seconds: int) -> str:
+        return f"open:{valve_id}:{seconds}"
+
+    def build_close_valve_obj(self, valve_id: int) -> str:
+        return f"close:{valve_id}"
+
+
+class FakeChannel:
+    def __init__(self, *, connected: bool = True, ack: bool = True) -> None:
+        self.connected = connected
+        self.devices = {LOCAL_ID: FakeLocalDevice()}
+        self._ack = ack
+        self.sent: list[Any] = []
+        self.stopped = False
+
+    async def async_send_command(self, request: Any) -> bool:
+        self.sent.append(request)
+        return self._ack
+
+    async def async_stop(self) -> None:
+        self.stopped = True
+
+
+def _cloud_device() -> MagicMock:
+    device = MagicMock()
+    device.device_id = "dev-uuid"
+    device.serial = CLOUD_SERIAL
+    device.valves = {"dev-uuid:1": MagicMock()}
+    return device
+
+
+@pytest.fixture
+async def coordinator(hass: HomeAssistant) -> GardenaCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, title="My Garden")
+    entry.add_to_hass(hass)
+    coord = GardenaCoordinator(hass, entry, async_get_clientsession(hass))
+    coord.data = {"dev-uuid": _cloud_device()}
+    coord._client = AsyncMock()
+    return coord
+
+
+async def test_command_goes_local_when_connected(coordinator: GardenaCoordinator) -> None:
+    channel = FakeChannel(connected=True, ack=True)
+    coordinator._local_channel = channel  # type: ignore[assignment]
+
+    await coordinator.async_send_command(
+        "dev-uuid:1", "VALVE_CONTROL", "START_SECONDS_TO_OVERRIDE", seconds=600
+    )
+
+    assert channel.sent == ["open:0:600"]
+    coordinator._client.async_send_command.assert_not_called()
+    assert coordinator.last_command_source("dev-uuid") == "local"
+
+
+async def test_command_falls_back_to_cloud_without_channel(
+    coordinator: GardenaCoordinator,
+) -> None:
+    await coordinator.async_send_command("dev-uuid:1", "VALVE_CONTROL", "STOP_UNTIL_NEXT_TASK")
+
+    coordinator._client.async_send_command.assert_called_once_with(
+        service_id="dev-uuid:1", control_type="VALVE_CONTROL", command="STOP_UNTIL_NEXT_TASK"
+    )
+    assert coordinator.last_command_source("dev-uuid") == "cloud"
+
+
+async def test_command_falls_back_when_local_not_acked(
+    coordinator: GardenaCoordinator,
+) -> None:
+    coordinator._local_channel = FakeChannel(connected=True, ack=False)  # type: ignore[assignment]
+
+    await coordinator.async_send_command("dev-uuid:1", "VALVE_CONTROL", "STOP_UNTIL_NEXT_TASK")
+
+    coordinator._client.async_send_command.assert_called_once()
+    assert coordinator.last_command_source("dev-uuid") == "cloud"
+
+
+async def test_local_overlay_pushes_update_on_change(
+    coordinator: GardenaCoordinator,
+) -> None:
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+    with patch(
+        "custom_components.gardena_smart_system_ng.coordinator.apply_local_state",
+        return_value=True,
+    ):
+        coordinator._on_local_devices_updated({LOCAL_ID: FakeLocalDevice()})
+    listener.assert_called()
+
+
+async def test_command_cloud_when_local_device_unknown(
+    coordinator: GardenaCoordinator,
+) -> None:
+    channel = FakeChannel(connected=True)
+    channel.devices = {}  # no local device matches the cloud serial
+    coordinator._local_channel = channel  # type: ignore[assignment]
+
+    await coordinator.async_send_command("dev-uuid:1", "VALVE_CONTROL", "STOP_UNTIL_NEXT_TASK")
+
+    coordinator._client.async_send_command.assert_called_once()
+    assert coordinator.last_command_source("dev-uuid") == "cloud"
+
+
+async def test_on_device_update_reasserts_local(coordinator: GardenaCoordinator) -> None:
+    coordinator._local_channel = FakeChannel(connected=True)  # type: ignore[assignment]
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+    device = coordinator.data["dev-uuid"]
+    with patch(
+        "custom_components.gardena_smart_system_ng.coordinator.apply_local_state",
+        return_value=True,
+    ):
+        coordinator._on_device_update("dev-uuid", device)
+    listener.assert_called()
+
+
+async def test_shutdown_stops_local_channel(coordinator: GardenaCoordinator) -> None:
+    channel = FakeChannel(connected=True)
+    coordinator._local_channel = channel  # type: ignore[assignment]
+    coordinator._auth = AsyncMock()  # avoid real token revocation on shutdown
+
+    await coordinator.async_shutdown()
+
+    assert channel.stopped is True
+    assert coordinator._local_channel is None
+
+
+async def test_ensure_channel_starts_and_stops_with_options(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=ENTRY_DATA,
+        options={OPT_LOCAL_ENABLE: True, OPT_LOCAL_HOST: "10.0.0.9"},
+        title="My Garden",
+    )
+    entry.add_to_hass(hass)
+    coord = GardenaCoordinator(hass, entry, async_get_clientsession(hass))
+
+    fake = MagicMock()
+    fake.async_start = AsyncMock()
+    fake.async_stop = AsyncMock()
+    with patch(_PATCH_LOCAL_CHANNEL, return_value=fake) as ctor:
+        await coord._async_ensure_local_channel()
+        ctor.assert_called_once()
+        fake.async_start.assert_awaited_once()
+
+        # Disable via options → channel is stopped and cleared.
+        hass.config_entries.async_update_entry(entry, options={OPT_LOCAL_ENABLE: False})
+        await coord._async_ensure_local_channel()
+        fake.async_stop.assert_awaited_once()
+        assert coord._local_channel is None

--- a/tests/components/gardena_smart_system_ng/test_local_channel.py
+++ b/tests/components/gardena_smart_system_ng/test_local_channel.py
@@ -3,18 +3,22 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
 import pytest
 from gardena_smart_local_api.messages import (
+    EgressMessageList,
     Entity,
     ErrorMessage,
     ErrorMetadata,
     Event,
     IngressMessageList,
     Reply,
+    Request,
 )
 from gardena_smart_local_api.resources import IpsoPath
 from homeassistant.core import HomeAssistant
 
+from custom_components.gardena_smart_system_ng import local_channel as local_channel_mod
 from custom_components.gardena_smart_system_ng.local_channel import (
     GardenaLocalChannel,
 )
@@ -145,8 +149,6 @@ async def test_full_session_discovers_and_applies_events(
     """Drive a whole connection lifetime against a fake gateway WebSocket."""
     import json
 
-    import aiohttp
-
     channel, updates, conn = _make_channel(hass)
     dev = "3034F8EE901EE94000001294"  # decodes to an Irrigation Control (model 31653)
     device_payload = {dev: {"device": {"0": {"model_number": {"vs": "31653"}}}}}
@@ -208,3 +210,124 @@ async def test_full_session_discovers_and_applies_events(
     assert dev in channel.devices  # discovery built the device
     assert True in conn  # the link reported connected
     assert len(updates) >= 1  # discovery/event notified the coordinator
+
+
+async def test_connected_property_default_false(hass: HomeAssistant) -> None:
+    channel, _, _ = _make_channel(hass)
+    assert channel.connected is False
+
+
+async def test_send_command_false_when_no_request_ids(hass: HomeAssistant) -> None:
+    channel, _, _ = _make_channel(hass)
+    ws = MagicMock()
+    ws.closed = False
+    channel._ws = ws
+    request = EgressMessageList([Request(entity=Entity(path="x"), op="read", request_id=None)])
+    assert await channel.async_send_command(request) is False
+
+
+async def test_send_command_false_on_transport_error(hass: HomeAssistant) -> None:
+    channel, _, _ = _make_channel(hass)
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_str = AsyncMock(side_effect=aiohttp.ClientError("boom"))
+    channel._ws = ws
+    request = EgressMessageList([Request(entity=Entity(path="x"), op="read", request_id="r")])
+    assert await channel.async_send_command(request) is False
+
+
+async def test_run_retries_after_session_error(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A session error is swallowed and the loop reconnects until stopped."""
+    channel, _, _ = _make_channel(hass)
+    monkeypatch.setattr(local_channel_mod, "LOCAL_RECONNECT_SCHEDULE", (0.001,))
+    calls: list[int] = []
+
+    async def fake_session() -> None:
+        calls.append(1)
+        if len(calls) == 1:
+            raise ValueError("boom")  # first attempt errors → reconnect
+        await asyncio.sleep(3600)  # second attempt blocks until cancelled
+
+    monkeypatch.setattr(channel, "_session_once", fake_session)
+    await channel.async_start()
+    for _ in range(50):
+        await asyncio.sleep(0.005)
+        if len(calls) >= 2:
+            break
+    await channel.async_stop()
+    assert len(calls) >= 2
+
+
+async def test_keepalive_returns_without_devices(hass: HomeAssistant) -> None:
+    channel, _, _ = _make_channel(hass)
+    channel.devices = {}  # type: ignore[assignment]
+    await channel._keepalive(MagicMock())  # returns immediately, no send
+
+
+async def test_keepalive_sends_until_closed(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    channel, _, _ = _make_channel(hass)
+    monkeypatch.setattr(local_channel_mod, "KEEPALIVE_INTERVAL_SECONDS", 0.001)
+    probe = MagicMock()
+    probe.model_dump_json = MagicMock(return_value="[]")
+    device = MagicMock()
+    device.build_refresh_online_status_obj = probe
+    channel.devices = {"d": device}  # type: ignore[assignment]
+
+    ws = MagicMock()
+    ws.send_str = AsyncMock()
+    states = [False, True]  # one iteration, then closed
+    type(ws).closed = property(lambda _self: states.pop(0) if states else True)
+
+    await channel._keepalive(ws)
+    ws.send_str.assert_awaited_once_with("[]")
+
+
+async def test_non_conforming_frame_is_ignored(hass: HomeAssistant) -> None:
+    channel, updates, _ = _make_channel(hass)
+    channel._on_raw("not-json")  # invalid JSON
+    channel._on_raw('{"not": "a list"}')  # valid JSON, wrong shape
+    assert updates == []
+
+
+async def test_error_frame_without_pending_is_logged(hass: HomeAssistant) -> None:
+    channel, _, _ = _make_channel(hass)
+    err = ErrorMessage(
+        metadata=ErrorMetadata(error_source="websocketd"),
+        payload={"vs": "boom"},
+        request_id="unknown",
+        success=False,
+    )
+    channel._handle_ingress(IngressMessageList([err]))  # no matching waiter → just logged
+
+
+async def test_event_without_device_is_ignored(hass: HomeAssistant) -> None:
+    channel, updates, _ = _make_channel(hass)
+    event = Event(
+        entity=Entity(device="", path=IpsoPath(object_name="lemonbeat")),
+        op="update",
+        payload={},
+    )
+    channel._handle_ingress(IngressMessageList([event]))
+    assert updates == []
+
+
+async def test_delete_event_removes_device(hass: HomeAssistant) -> None:
+    channel, updates, _ = _make_channel(hass)
+    channel.devices = {"d": MagicMock()}  # type: ignore[assignment]
+    event = Event(entity=Entity(device="d", path=IpsoPath()), op="delete", payload={})
+    channel._handle_ingress(IngressMessageList([event]))
+    assert "d" not in channel.devices
+    assert len(updates) == 1
+
+
+async def test_fail_pending_cancels_open_futures(hass: HomeAssistant) -> None:
+    channel, _, _ = _make_channel(hass)
+    fut: asyncio.Future[Reply] = asyncio.get_running_loop().create_future()
+    channel._pending["r"] = fut
+    channel._fail_pending()
+    assert fut.cancelled()
+    assert channel._pending == {}

--- a/tests/components/gardena_smart_system_ng/test_local_channel.py
+++ b/tests/components/gardena_smart_system_ng/test_local_channel.py
@@ -1,0 +1,210 @@
+"""Tests for the local gateway WebSocket channel's message handling."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from gardena_smart_local_api.messages import (
+    Entity,
+    ErrorMessage,
+    ErrorMetadata,
+    Event,
+    IngressMessageList,
+    Reply,
+)
+from gardena_smart_local_api.resources import IpsoPath
+from homeassistant.core import HomeAssistant
+
+from custom_components.gardena_smart_system_ng.local_channel import (
+    GardenaLocalChannel,
+)
+
+
+def _make_channel(hass: HomeAssistant) -> tuple[GardenaLocalChannel, list, list]:
+    updates: list = []
+    conn: list[bool] = []
+    channel = GardenaLocalChannel(
+        hass,
+        host="10.0.0.9",
+        password="deadbeef",
+        on_devices_updated=updates.append,
+        on_connection_change=conn.append,
+    )
+    return channel, updates, conn
+
+
+async def test_reply_resolves_pending_future(hass: HomeAssistant) -> None:
+    """A Reply with a matching request_id resolves the waiter's future."""
+    channel, _, _ = _make_channel(hass)
+    fut: asyncio.Future[Reply] = asyncio.get_running_loop().create_future()
+    channel._pending["req-1"] = fut
+
+    reply = Reply(request_id="req-1", success=True, payload={"vi": 0})
+    channel._handle_ingress(IngressMessageList([reply]))
+
+    assert fut.done()
+    assert fut.result().success is True
+    assert "req-1" not in channel._pending
+
+
+async def test_error_message_fails_pending_future(hass: HomeAssistant) -> None:
+    """An ErrorMessage for a pending request resolves it as unsuccessful."""
+    channel, _, _ = _make_channel(hass)
+    fut: asyncio.Future[Reply] = asyncio.get_running_loop().create_future()
+    channel._pending["req-2"] = fut
+
+    err = ErrorMessage(
+        metadata=ErrorMetadata(error_source="websocketd"),
+        payload={"vs": "nope"},
+        request_id="req-2",
+        success=False,
+    )
+    channel._handle_ingress(IngressMessageList([err]))
+
+    assert fut.done()
+    assert fut.result().success is False
+
+
+async def test_unknown_device_event_is_ignored(hass: HomeAssistant) -> None:
+    """An event for a device not in the map is dropped without notifying."""
+    channel, updates, _ = _make_channel(hass)
+    event = Event(
+        entity=Entity(device="unknown", path=IpsoPath(object_name="lemonbeat")),
+        op="update",
+        payload={},
+    )
+    channel._handle_ingress(IngressMessageList([event]))
+
+    assert updates == []  # nothing changed → no coordinator notification
+
+
+async def test_send_command_false_when_disconnected(hass: HomeAssistant) -> None:
+    """With no live socket, a command fails fast so the cloud path is used."""
+    channel, _, _ = _make_channel(hass)
+    assert channel._ws is None
+    from gardena_smart_local_api.messages import EgressMessageList, Request
+
+    request = EgressMessageList([Request(entity=Entity(path="x"), op="read")])
+    assert await channel.async_send_command(request) is False
+
+
+async def test_connection_change_fires_only_on_transition(hass: HomeAssistant) -> None:
+    """The connection callback fires on edges, not on repeated same-state sets."""
+    channel, _, conn = _make_channel(hass)
+    channel._set_connected(True)
+    channel._set_connected(True)  # no-op
+    channel._set_connected(False)
+    assert conn == [True, False]
+
+
+async def test_send_command_resolves_on_matching_reply(hass: HomeAssistant) -> None:
+    """A command send succeeds when the gateway acks its request_id."""
+    from gardena_smart_local_api.messages import EgressMessageList, Request
+
+    channel, _, _ = _make_channel(hass)
+    fake_ws = MagicMock()
+    fake_ws.closed = False
+    fake_ws.send_str = AsyncMock()
+    channel._ws = fake_ws
+
+    request = EgressMessageList(
+        [
+            Request(
+                entity=Entity(path="lemonbeat/0/watering_timer_1"), op="write", request_id="rid-1"
+            )
+        ]
+    )
+    task = asyncio.create_task(channel.async_send_command(request))
+    await asyncio.sleep(0)  # let it send and register the pending future
+    channel._handle_ingress(IngressMessageList([Reply(request_id="rid-1", success=True)]))
+
+    assert await task is True
+    fake_ws.send_str.assert_awaited_once()
+
+
+async def test_event_updates_known_device(hass: HomeAssistant) -> None:
+    """An update event for a known device applies and notifies the owner."""
+    channel, updates, _ = _make_channel(hass)
+    device = MagicMock()
+    channel.devices = {"d": device}  # type: ignore[assignment]
+
+    event = Event(
+        entity=Entity(device="d", path=IpsoPath(object_name="lemonbeat")),
+        op="update",
+        payload={},
+    )
+    channel._handle_ingress(IngressMessageList([event]))
+
+    device.update_data.assert_called_once()
+    assert len(updates) == 1  # coordinator notified once
+
+
+async def test_full_session_discovers_and_applies_events(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive a whole connection lifetime against a fake gateway WebSocket."""
+    import json
+
+    import aiohttp
+
+    channel, updates, conn = _make_channel(hass)
+    dev = "3034F8EE901EE94000001294"  # decodes to an Irrigation Control (model 31653)
+    device_payload = {dev: {"device": {"0": {"model_number": {"vs": "31653"}}}}}
+
+    def _text(obj: object) -> aiohttp.WSMessage:
+        return aiohttp.WSMessage(aiohttp.WSMsgType.TEXT, json.dumps(obj), "")
+
+    class FakeWS:
+        def __init__(self) -> None:
+            self._q: asyncio.Queue[aiohttp.WSMessage] = asyncio.Queue()
+            self.closed = False
+            self._answered = False
+
+        async def send_str(self, data: str) -> None:
+            if self._answered:
+                return
+            self._answered = True
+            for msg in json.loads(data):  # answer each discovery request_id
+                rid = msg.get("request_id")
+                await self._q.put(
+                    _text([{"request_id": rid, "success": True, "payload": device_payload}])
+                )
+            # a live device update, then a server-initiated close
+            await self._q.put(
+                _text(
+                    [
+                        {
+                            "entity": {"device": dev, "path": "lemonbeat/0"},
+                            "op": "update",
+                            "payload": {"_urn": "x", "rf_link_quality": {"vi": 100}},
+                        }
+                    ]
+                )
+            )
+            await self._q.put(aiohttp.WSMessage(aiohttp.WSMsgType.CLOSED, None, ""))
+
+        def __aiter__(self) -> "FakeWS":
+            return self
+
+        async def __anext__(self) -> aiohttp.WSMessage:
+            return await self._q.get()
+
+    class FakeCM:
+        async def __aenter__(self) -> FakeWS:
+            return FakeWS()
+
+        async def __aexit__(self, *exc: object) -> bool:
+            return False
+
+    monkeypatch.setattr(channel._session, "ws_connect", lambda *a, **k: FakeCM())
+
+    await channel.async_start()
+    for _ in range(20):  # pump the loop until discovery has built the device
+        await asyncio.sleep(0.01)
+        if dev in channel.devices:
+            break
+    await channel.async_stop()
+
+    assert dev in channel.devices  # discovery built the device
+    assert True in conn  # the link reported connected
+    assert len(updates) >= 1  # discovery/event notified the coordinator

--- a/tests/components/gardena_smart_system_ng/test_local_ids.py
+++ b/tests/components/gardena_smart_system_ng/test_local_ids.py
@@ -1,0 +1,43 @@
+"""Tests for local gateway id → cloud serial mapping."""
+
+import pytest
+
+from custom_components.gardena_smart_system_ng.local_ids import (
+    cloud_serial_from_local_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("local_id", "expected_serial"),
+    [
+        # Verified live against the running cloud integration's device serials.
+        ("3034F8EE901EE94000001294", "00004756"),  # Irrigation Control
+        ("3034F8319C02BF8000003F81", "00016257"),  # Dual Water Control (right)
+        ("3034F8319C02BF800000462E", "00017966"),  # Dual Water Control (left)
+    ],
+)
+def test_known_devices_map_to_cloud_serial(local_id: str, expected_serial: str) -> None:
+    """A local SGTIN96 id decodes to the zero-padded 8-digit cloud serial."""
+    assert cloud_serial_from_local_id(local_id) == expected_serial
+
+
+def test_result_is_always_eight_digits() -> None:
+    """The cloud serial is zero-padded to a stable 8-character width."""
+    serial = cloud_serial_from_local_id("3034F8EE901EE94000001294")
+    assert serial is not None
+    assert len(serial) == 8
+    assert serial.isdigit()
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "",  # empty
+        "not-hex",  # non-hex
+        "3034F8EE901E",  # too short (12 hex, not 24)
+        "00000000000000000000000000000000",  # invalid SGTIN96 header
+    ],
+)
+def test_undecodable_ids_return_none(bad_id: str) -> None:
+    """A non-SGTIN96 id yields None so the caller can skip it, not guess."""
+    assert cloud_serial_from_local_id(bad_id) is None

--- a/tests/components/gardena_smart_system_ng/test_local_translate.py
+++ b/tests/components/gardena_smart_system_ng/test_local_translate.py
@@ -1,0 +1,210 @@
+"""Tests for cloud<->local command and state translation."""
+
+from typing import Any
+
+from aiogardenasmart.const import ControlType, ValveActivity
+
+from aiogardenasmart import Device, SensorService, ValveService
+from custom_components.gardena_smart_system_ng.local_translate import (
+    CMD_START,
+    CMD_STOP,
+    apply_local_state,
+    build_local_command,
+    local_valve_position,
+    sorted_valve_service_ids,
+)
+
+
+class FakeLocalDevice:
+    """A stand-in local-library device recording builder calls."""
+
+    def __init__(self, *, valve_ids: list[int] | None = None) -> None:
+        self.valve_ids = valve_ids if valve_ids is not None else []
+        self.calls: list[tuple[Any, ...]] = []
+        self._open: dict[int, bool | None] = {}
+        self.online: bool | None = None
+        self.soil_moisture: int | None = None
+        self.temperature: int | None = None
+
+    # command builders
+    def build_open_valve_obj(self, valve_id: int, seconds: int) -> str:
+        self.calls.append(("open", valve_id, seconds))
+        return f"open:{valve_id}:{seconds}"
+
+    def build_close_valve_obj(self, valve_id: int) -> str:
+        self.calls.append(("close", valve_id))
+        return f"close:{valve_id}"
+
+    def build_enable_output_obj(self, seconds: int) -> str:
+        self.calls.append(("enable", seconds))
+        return f"enable:{seconds}"
+
+    def build_disable_output_obj(self) -> str:
+        self.calls.append(("disable",))
+        return "disable"
+
+    def build_start_mowing_obj(self, seconds: int) -> str:
+        self.calls.append(("mow", seconds))
+        return f"mow:{seconds}"
+
+    def build_stop_mowing_obj(self) -> str:
+        self.calls.append(("park",))
+        return "park"
+
+    # accessors
+    def is_valve_open(self, valve_id: int) -> bool | None:
+        return self._open.get(valve_id)
+
+    def is_online(self) -> bool | None:
+        return self.online
+
+
+def _valve(service_id: str, activity: str) -> ValveService:
+    return ValveService(
+        service_id=service_id,
+        device_id=service_id.split(":")[0],
+        name="v",
+        activity=activity,
+        state="OK",
+        duration=None,
+        duration_timestamp=None,
+        last_error_code=None,
+    )
+
+
+def _device_with_valves(activities: dict[str, str]) -> Device:
+    return Device(
+        device_id="uuid",
+        location_id="loc",
+        valves={sid: _valve(sid, act) for sid, act in activities.items()},
+    )
+
+
+def test_valves_sorted_by_numeric_suffix() -> None:
+    device = _device_with_valves({"uuid:10": "CLOSED", "uuid:2": "CLOSED", "uuid:1": "CLOSED"})
+    assert sorted_valve_service_ids(device) == ["uuid:1", "uuid:2", "uuid:10"]
+    assert local_valve_position(device, "uuid:2") == 1
+    assert local_valve_position(device, "uuid:99") is None
+
+
+def test_valve_open_maps_to_positional_local_valve() -> None:
+    device = _device_with_valves({"uuid:1": "CLOSED", "uuid:2": "CLOSED"})
+    local = FakeLocalDevice(valve_ids=[0, 1])
+    result = build_local_command(local, device, "uuid:2", ControlType.VALVE, CMD_START, seconds=600)
+    assert result == "open:1:600"  # 2nd cloud valve → 2nd local valve (id 1)
+    assert local.calls == [("open", 1, 600)]
+
+
+def test_valve_close_maps_to_close_builder() -> None:
+    device = _device_with_valves({"uuid:1": "MANUAL_WATERING"})
+    local = FakeLocalDevice(valve_ids=[0])
+    result = build_local_command(local, device, "uuid:1", ControlType.VALVE, CMD_STOP, seconds=None)
+    assert result == "close:0"
+
+
+def test_power_socket_commands() -> None:
+    device = Device(device_id="uuid", location_id="loc")
+    local = FakeLocalDevice()
+    assert (
+        build_local_command(local, device, "uuid", ControlType.POWER_SOCKET, CMD_START, seconds=300)
+        == "enable:300"
+    )
+    assert (
+        build_local_command(local, device, "uuid", ControlType.POWER_SOCKET, CMD_STOP, seconds=None)
+        == "disable"
+    )
+
+
+def test_unmappable_command_returns_none() -> None:
+    device = _device_with_valves({"uuid:1": "CLOSED"})
+    local = FakeLocalDevice(valve_ids=[0])
+    # Unknown command verb → cloud fallback.
+    assert (
+        build_local_command(local, device, "uuid:1", ControlType.VALVE, "START_DONT_OVERRIDE", None)
+        is None
+    )
+
+
+def test_state_overlay_flips_valve_activity() -> None:
+    device = _device_with_valves(
+        {"uuid:1": ValveActivity.CLOSED, "uuid:2": ValveActivity.MANUAL_WATERING}
+    )
+    local = FakeLocalDevice(valve_ids=[0, 1])
+    local._open = {0: True, 1: False}  # local says v0 open, v1 closed
+
+    assert apply_local_state(local, device) is True
+    assert device.valves["uuid:1"].activity == ValveActivity.MANUAL_WATERING
+    assert device.valves["uuid:2"].activity == ValveActivity.CLOSED
+
+
+def test_state_overlay_preserves_agreeing_scheduled_label() -> None:
+    device = _device_with_valves({"uuid:1": ValveActivity.SCHEDULED_WATERING})
+    local = FakeLocalDevice(valve_ids=[0])
+    local._open = {0: True}  # both agree the valve is open
+
+    assert apply_local_state(local, device) is False
+    # Scheduled label must NOT be downgraded to manual when they agree.
+    assert device.valves["uuid:1"].activity == ValveActivity.SCHEDULED_WATERING
+
+
+def test_mower_start_and_park() -> None:
+    device = Device(device_id="uuid", location_id="loc")
+    local = FakeLocalDevice()
+    assert (
+        build_local_command(local, device, "uuid", ControlType.MOWER, CMD_START, seconds=900)
+        == "mow:900"
+    )
+    assert (
+        build_local_command(
+            local, device, "uuid", ControlType.MOWER, "PARK_UNTIL_FURTHER_NOTICE", None
+        )
+        == "park"
+    )
+
+
+def test_unknown_control_type_returns_none() -> None:
+    device = Device(device_id="uuid", location_id="loc")
+    local = FakeLocalDevice()
+    assert build_local_command(local, device, "uuid", "LIGHT_CONTROL", CMD_START, 60) is None
+
+
+def test_valve_command_none_when_position_missing() -> None:
+    device = _device_with_valves({"uuid:1": "CLOSED"})
+    local = FakeLocalDevice(valve_ids=[0])
+    # service_id not present on the device → no positional match → cloud fallback
+    assert build_local_command(local, device, "uuid:9", ControlType.VALVE, CMD_STOP, None) is None
+
+
+def test_call_returns_none_when_builder_absent() -> None:
+    device = Device(device_id="uuid", location_id="loc")
+
+    class Bare:  # a local object lacking any command builders
+        pass
+
+    assert (
+        build_local_command(Bare(), device, "uuid", ControlType.POWER_SOCKET, CMD_STOP, None)
+        is None
+    )
+
+
+def test_state_overlay_updates_sensor_values() -> None:
+    device = Device(
+        device_id="uuid",
+        location_id="loc",
+        sensor=SensorService(
+            service_id="uuid:sensor",
+            device_id="uuid",
+            soil_humidity=None,
+            soil_temperature=None,
+            ambient_temperature=None,
+            light_intensity=None,
+        ),
+    )
+    local = FakeLocalDevice()
+    local.soil_moisture = 55
+    local.temperature = 24
+
+    assert apply_local_state(local, device) is True
+    assert device.sensor is not None
+    assert device.sensor.soil_humidity == 55
+    assert device.sensor.soil_temperature == 24.0

--- a/tests/components/gardena_smart_system_ng/test_local_translate.py
+++ b/tests/components/gardena_smart_system_ng/test_local_translate.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from aiogardenasmart.const import ControlType, ValveActivity
 
-from aiogardenasmart import Device, SensorService, ValveService
+from aiogardenasmart import CommonService, Device, SensorService, ValveService
 from custom_components.gardena_smart_system_ng.local_translate import (
     CMD_START,
     CMD_STOP,
@@ -185,6 +185,62 @@ def test_call_returns_none_when_builder_absent() -> None:
         build_local_command(Bare(), device, "uuid", ControlType.POWER_SOCKET, CMD_STOP, None)
         is None
     )
+
+
+def test_power_socket_unknown_command_returns_none() -> None:
+    device = Device(device_id="uuid", location_id="loc")
+    local = FakeLocalDevice()
+    assert build_local_command(local, device, "uuid", ControlType.POWER_SOCKET, "WEIRD", 60) is None
+
+
+def test_mower_unmappable_command_returns_none() -> None:
+    device = Device(device_id="uuid", location_id="loc")
+    local = FakeLocalDevice()
+    # START_DONT_OVERRIDE has no local equivalent → cloud fallback.
+    assert (
+        build_local_command(local, device, "uuid", ControlType.MOWER, "START_DONT_OVERRIDE", None)
+        is None
+    )
+
+
+def _common(rf_link_state: str) -> CommonService:
+    return CommonService(
+        device_id="uuid",
+        name="n",
+        serial="00004756",
+        model_type="m",
+        battery_level=None,
+        battery_state=None,
+        rf_link_level=None,
+        rf_link_state=rf_link_state,
+    )
+
+
+def test_state_overlay_sets_online_from_local() -> None:
+    device = Device(device_id="uuid", location_id="loc", common=_common("OFFLINE"))
+    local = FakeLocalDevice()
+    local.online = True
+
+    assert apply_local_state(local, device) is True
+    assert device.common is not None
+    assert device.common.rf_link_state == "ONLINE"
+
+
+def test_state_overlay_online_noop_when_already_online() -> None:
+    device = Device(device_id="uuid", location_id="loc", common=_common("ONLINE"))
+    local = FakeLocalDevice()
+    local.online = True  # agrees with cloud → no change
+
+    assert apply_local_state(local, device) is False
+
+
+def test_overlay_valves_skips_unknown_and_stops_past_local_count() -> None:
+    device = _device_with_valves({"uuid:1": ValveActivity.CLOSED, "uuid:2": ValveActivity.CLOSED})
+    local = FakeLocalDevice(valve_ids=[0])  # fewer local valves than cloud
+    local._open = {0: None}  # local can't tell → skip valve 0; valve 1 has no local peer
+
+    assert apply_local_state(local, device) is False
+    assert device.valves["uuid:1"].activity == ValveActivity.CLOSED
 
 
 def test_state_overlay_updates_sensor_values() -> None:

--- a/tests/components/gardena_smart_system_ng/test_mqtt_bridge_coverage.py
+++ b/tests/components/gardena_smart_system_ng/test_mqtt_bridge_coverage.py
@@ -1,0 +1,52 @@
+"""Coverage for MqttBridge publish error paths and the command subscription."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.gardena_smart_system_ng.mqtt_bridge import MqttBridge
+
+from .conftest import make_mock_device
+
+_MQTT = "custom_components.gardena_smart_system_ng.mqtt_bridge.mqtt"
+
+
+async def test_publish_device_state_swallows_broker_error(hass: HomeAssistant) -> None:
+    bridge = MqttBridge(hass, "gardena", publish_states=True)
+    bridge._started = True
+    with patch(f"{_MQTT}.async_publish", AsyncMock(side_effect=HomeAssistantError("down"))):
+        await bridge.async_publish_device_state("d", make_mock_device(valve_count=1))
+
+
+async def test_publish_availability_paths(hass: HomeAssistant) -> None:
+    bridge = MqttBridge(hass, "gardena", publish_states=True)
+    bridge._started = False
+    await bridge.async_publish_availability("d", True)  # not started → early return
+    bridge._started = True
+    with patch(f"{_MQTT}.async_publish", AsyncMock(side_effect=HomeAssistantError("down"))):
+        await bridge.async_publish_availability("d", False)  # broker error swallowed
+
+
+async def test_subscribe_and_command_dispatch(hass: HomeAssistant) -> None:
+    handler = AsyncMock()
+    bridge = MqttBridge(hass, "gardena", subscribe_commands=True)
+    bridge._command_handler = handler
+
+    captured: dict[str, object] = {}
+
+    async def fake_subscribe(_hass: object, _topic: str, cb: object) -> MagicMock:
+        captured["cb"] = cb
+        return MagicMock()
+
+    with patch(f"{_MQTT}.async_subscribe", fake_subscribe):
+        await bridge._async_subscribe()
+
+    on_command = captured["cb"]
+    on_command(MagicMock(topic="gardena/short", payload="{}"))  # too few parts → ignored
+    on_command(MagicMock(topic="gardena/dev/command", payload="not-json"))  # bad JSON → warned
+    on_command(MagicMock(topic="gardena/dev/command", payload='{"action": "x"}'))  # dispatched
+    await hass.async_block_till_done()
+    handler.assert_called_once()

--- a/tests/components/gardena_smart_system_ng/test_platform_command_coverage.py
+++ b/tests/components/gardena_smart_system_ng/test_platform_command_coverage.py
@@ -1,0 +1,136 @@
+"""Coverage for platform command internals (expected-state probes, optimistic state)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:
+    from pytest_homeassistant_custom_component.common import (
+        MockConfigEntry,  # type: ignore[no-redef]
+    )
+
+from custom_components.gardena_smart_system_ng import entity as entity_mod
+from custom_components.gardena_smart_system_ng import gardena_event as event_mod
+from custom_components.gardena_smart_system_ng.const import CONF_API_TYPE, DOMAIN
+from custom_components.gardena_smart_system_ng.coordinator import GardenaCoordinator
+from custom_components.gardena_smart_system_ng.gardena_event import GardenaValveEventEntity
+from custom_components.gardena_smart_system_ng.lawn_mower import GardenaLawnMowerEntity
+from custom_components.gardena_smart_system_ng.switch import GardenaPowerSocketEntity
+from custom_components.gardena_smart_system_ng.valve import GardenaValveEntity
+
+from .conftest import ENTRY_DATA, make_mock_device
+
+
+@pytest.fixture
+async def coord(hass: HomeAssistant) -> GardenaCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, title="My Garden")
+    entry.add_to_hass(hass)
+    coordinator = GardenaCoordinator(hass, entry, async_get_clientsession(hass))
+    coordinator._auth = AsyncMock()
+    return coordinator
+
+
+def test_valve_expected_check_and_optimistic(coord: GardenaCoordinator) -> None:
+    device = make_mock_device(valve_count=1)
+    service_id = next(iter(device.valves))
+    entity = GardenaValveEntity(coord, device, service_id)
+
+    assert entity._make_expected_state_check("NOPE") is None  # unknown command
+    check = entity._make_expected_state_check("STOP_UNTIL_NEXT_TASK")
+    assert check is not None
+
+    coord.data = {}
+    assert check() is False  # device missing
+    no_valve = make_mock_device(valve_count=0)
+    no_valve.valves = {}
+    coord.data = {no_valve.device_id: no_valve}
+    assert check() is False  # valve missing
+    closed = make_mock_device(valve_count=1)  # activity == CLOSED matches STOP target
+    coord.data = {closed.device_id: closed}
+    assert check() is True
+
+    coord.data = {}
+    entity._apply_optimistic_state("STOP_UNTIL_NEXT_TASK", {})  # valve None → return
+    coord.data = {device.device_id: device}
+    entity._apply_optimistic_state("NOPE", {})  # unknown command → return
+
+
+def test_switch_expected_check_and_optimistic(coord: GardenaCoordinator) -> None:
+    device = make_mock_device(has_power_socket=True)
+    entity = GardenaPowerSocketEntity(coord, device)
+
+    assert entity._make_expected_state_check("NOPE") is None
+    check = entity._make_expected_state_check("STOP_UNTIL_NEXT_TASK")
+    assert check is not None
+
+    coord.data = {}
+    assert check() is False  # device missing
+    no_ps = make_mock_device(has_power_socket=False)
+    coord.data = {no_ps.device_id: no_ps}
+    assert check() is False  # power_socket missing
+    coord.data = {device.device_id: device}  # activity OFF matches STOP target
+    assert check() is True
+
+    coord.data = {}
+    entity._apply_optimistic_state("STOP_UNTIL_NEXT_TASK", {})  # device None → return
+    coord.data = {device.device_id: device}
+    entity._apply_optimistic_state("NOPE", {})  # unknown command → return
+
+
+def test_lawn_mower_expected_check(coord: GardenaCoordinator) -> None:
+    device = make_mock_device(has_mower=True)
+    entity = GardenaLawnMowerEntity(coord, device)
+
+    assert entity._make_expected_state_check(None) is None
+    check = entity._make_expected_state_check("parked")
+    assert check is not None
+    coord.data = {}
+    assert check() is False  # device missing
+
+
+def test_valve_event_handles_missing_valve(coord: GardenaCoordinator) -> None:
+    device = make_mock_device(valve_count=1)
+    service_id = next(iter(device.valves))
+    entity = GardenaValveEventEntity(coord, device, service_id)
+    entity.async_write_ha_state = MagicMock()  # avoid real HA state write
+
+    no_valve = make_mock_device(valve_count=0)
+    no_valve.valves = {}
+    coord.data = {no_valve.device_id: no_valve}
+    entity._handle_coordinator_update()  # valve gone → delegate to base and return
+    entity.async_write_ha_state.assert_called()
+
+
+async def test_wait_for_expected_state_confirms_after_push(
+    coord: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(entity_mod, "COMMAND_POLL_AFTER_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(entity_mod, "COMMAND_POLL_INTERVAL_SECONDS", 0.001)
+    device = make_mock_device(valve_count=1)
+    service_id = next(iter(device.valves))
+    entity = GardenaValveEntity(coord, device, service_id)
+    coord._ws_push_at[entity._device_id] = 100.0  # a push newer than marker 0.0
+
+    calls: list[int] = []
+
+    def check() -> bool:
+        calls.append(1)
+        return len(calls) > 1  # not confirmed on the first probe, confirmed after
+
+    assert await entity._async_wait_for_expected_state(check, 0.0) is True
+
+
+async def test_event_setup_skips_automower(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={**ENTRY_DATA, CONF_API_TYPE: "automower"}, title="Mower"
+    )
+    entry.add_to_hass(hass)
+    added = MagicMock()
+    await event_mod.async_setup_entry(hass, entry, added)  # early return for automower
+    added.assert_not_called()

--- a/tests/components/gardena_smart_system_ng/test_sensor_coverage.py
+++ b/tests/components/gardena_smart_system_ng/test_sensor_coverage.py
@@ -1,0 +1,65 @@
+"""Coverage for the per-service sensor `native_value` None branches."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+try:
+    from tests.common import MockConfigEntry
+except ImportError:
+    from pytest_homeassistant_custom_component.common import (
+        MockConfigEntry,  # type: ignore[no-redef]
+    )
+
+from custom_components.gardena_smart_system_ng.const import DOMAIN
+from custom_components.gardena_smart_system_ng.coordinator import GardenaCoordinator
+from custom_components.gardena_smart_system_ng.sensor import (
+    GardenaPowerSocketRemainingDurationSensor,
+    GardenaValveErrorSensor,
+    GardenaValveRemainingDurationSensor,
+    GardenaValveSetErrorSensor,
+    GardenaValveStateSensor,
+)
+
+from .conftest import ENTRY_DATA, make_mock_device
+
+
+@pytest.fixture
+async def coord(hass: HomeAssistant) -> GardenaCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, title="My Garden")
+    entry.add_to_hass(hass)
+    coordinator = GardenaCoordinator(hass, entry, async_get_clientsession(hass))
+    coordinator._auth = AsyncMock()
+    return coordinator
+
+
+def test_sensor_native_value_none_branches(coord: GardenaCoordinator) -> None:
+    device = make_mock_device(valve_count=1, has_power_socket=True)
+    device.valve_set = MagicMock()
+    service_id = next(iter(device.valves))
+
+    sensors = [
+        GardenaValveRemainingDurationSensor(coord, device, service_id),
+        GardenaValveErrorSensor(coord, device, service_id),
+        GardenaValveStateSensor(coord, device, service_id),
+        GardenaPowerSocketRemainingDurationSensor(coord, device),
+        GardenaValveSetErrorSensor(coord, device),
+    ]
+
+    # 1) Device missing from coordinator data → `_device` is None.
+    coord.data = {}
+    for sensor in sensors:
+        assert sensor.native_value is None
+
+    # 2) Device present but its service objects are gone → second None branch.
+    stripped = make_mock_device(valve_count=0, has_power_socket=False)
+    stripped.valves = {}
+    stripped.power_socket = None
+    stripped.valve_set = None
+    coord.data = {stripped.device_id: stripped}
+    for sensor in sensors:
+        assert sensor.native_value is None


### PR DESCRIPTION
## Summary

Adds an optional **local WebSocket channel** to the GARDENA smart Gateway, alongside the existing cloud path, built on the official [`gardena-smart-local-api`](https://github.com/cloudless-garden/gardena-smart-local-api) (GARDENA GmbH, LGPL-3.0).

When enabled **and reachable**:
- **Local state takes precedence** over the cloud WebSocket (`_on_device_update` re-asserts local after each cloud push).
- **Commands are sent local-first**, with the proven cloud path as automatic fallback.
- Lower latency; monitoring and control keep working during a cloud/internet outage.

The gateway sends **no initial state snapshot**, so the cloud remains the source of the initial device set after a restart — local is a live-update + command **overlay** (`iot_class` stays `cloud_push`).

## What's included
- **`local_ids.py`** — SGTIN96 gateway id → cloud serial mapping (verified live: `3034F8EE901E…` → `00004756`, etc.)
- **`local_channel.py`** — WebSocket transport on the **injected HA session** (Platinum `inject-websession`), reconnect ladder, `request_id` reply correlation, self-signed TLS, no app-level pings (firmware 10.4.4 rejects them)
- **`local_translate.py`** — cloud↔local command + state translation with **positional valve mapping**
- **`coordinator.py`** — `async_send_command` facade (local-first + source tracking), local-precedence overlay, channel lifecycle; `valve`/`switch`/`lawn_mower` route through the facade
- **Config flow** options (enable / host / password / port)
- **UX**: *Local gateway connected* binary sensor + per-device *Last command via* (`local`/`cloud`) diagnostic sensor
- Diagnostics (status + password redaction), translations (strings/en/de), README (DE+EN, incl. the one-time `websocketd` activation)

## Quality gates
- ✅ **673 tests pass** (637 existing + 36 new), **0 regressions**
- ✅ `mypy --strict` clean (36 modules)
- ✅ `ruff check` + `format` clean
- ✅ Coverage **95%** — Platinum threshold held

## Notes / follow-ups
- Requires a **one-time gateway shell activation** of `websocketd` (documented) — the integration cannot do it.
- If Home Assistant is on a different VLAN than the gateway, it must be allowed to reach TCP `8443`.
- The positional valve↔service-id mapping assumes both sides enumerate a device's valves in the same physical order (documented; worth confirming on a multi-valve controller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)