### PR TITLE
Charge only cloud commands against the API budget

### DIFF
--- a/custom_components/gardena_smart_system_ng/coordinator.py
+++ b/custom_components/gardena_smart_system_ng/coordinator.py
@@ -177,11 +177,20 @@ class GardenaCoordinator(BaseSmartSystemCoordinator[Device]):
         place of the cloud client. Records which route actually carried the
         command (see ``last_command_source``). A cloud-path failure propagates
         exactly as before so the existing retry/timeout logic is unaffected.
+
+        Throttling and API-quota accounting apply to the **cloud path only**: a
+        command carried locally consumes no quota, is not rate-limited, and
+        works even when the cloud budget is exhausted.
         """
         device_id = service_id.split(":")[0]
         if await self._try_local_command(device_id, service_id, control_type, command, params):
             self._last_command_source[device_id] = "local"
             return
+        # Only a real cloud request counts against the monthly quota and the
+        # command throttle. Raises HomeAssistantError if throttled/exhausted;
+        # that propagates uncaught through the retry engine, exactly as before.
+        self.check_command_throttle()
+        self._api_budget.increment()
         # Forward as keywords to preserve the exact cloud-client call convention.
         await self._client.async_send_command(
             service_id=service_id, control_type=control_type, command=command, **params

--- a/custom_components/gardena_smart_system_ng/entity.py
+++ b/custom_components/gardena_smart_system_ng/entity.py
@@ -148,7 +148,12 @@ class GardenaEntity(CoordinatorEntity[GardenaCoordinator]):
         a 504 cannot cause unwanted double execution.
 
         Polling reads the in-memory coordinator only — no extra REST calls.
-        The API budget counts each attempt that actually fires.
+
+        API-quota accounting and command throttling live in the coordinator's
+        ``async_send_command`` facade, on the cloud branch only: a command that
+        the facade routes to the local gateway consumes no quota and is not
+        throttled (and works even when the cloud budget is exhausted). Each
+        cloud attempt — including retries — still counts exactly once.
 
         Non-timeout errors (auth, deterministic 4xx, other library errors)
         short-circuit immediately — there is nothing a retry would fix.
@@ -157,8 +162,6 @@ class GardenaEntity(CoordinatorEntity[GardenaCoordinator]):
 
         for attempt in range(COMMAND_RETRY_ATTEMPTS):
             is_last_attempt = attempt == COMMAND_RETRY_ATTEMPTS - 1
-            self.coordinator.check_command_throttle()
-            self.coordinator.api_budget.increment()
             # Capture the WebSocket push marker *before* sending. Only a push
             # that arrives after this point proves the command landed; the
             # cached state may still hold a stale activity from a previous

--- a/tests/components/gardena_smart_system_ng/test_coordinator_local.py
+++ b/tests/components/gardena_smart_system_ng/test_coordinator_local.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -117,6 +118,59 @@ async def test_command_falls_back_when_local_not_acked(
 
     coordinator._client.async_send_command.assert_called_once()
     assert coordinator.last_command_source("dev-uuid") == "cloud"
+
+
+async def test_local_command_does_not_touch_budget_or_throttle(
+    coordinator: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    coordinator._local_channel = FakeChannel(connected=True, ack=True)  # type: ignore[assignment]
+    throttle = MagicMock()
+    increment = MagicMock()
+    monkeypatch.setattr(coordinator, "check_command_throttle", throttle)
+    monkeypatch.setattr(coordinator._api_budget, "increment", increment)
+
+    await coordinator.async_send_command(
+        "dev-uuid:1", "VALVE_CONTROL", "START_SECONDS_TO_OVERRIDE", seconds=600
+    )
+
+    throttle.assert_not_called()  # local command is not rate-limited
+    increment.assert_not_called()  # and consumes no cloud quota
+    assert coordinator.last_command_source("dev-uuid") == "local"
+
+
+async def test_cloud_command_throttles_and_counts_budget(
+    coordinator: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    throttle = MagicMock()
+    increment = MagicMock()
+    monkeypatch.setattr(coordinator, "check_command_throttle", throttle)
+    monkeypatch.setattr(coordinator._api_budget, "increment", increment)
+
+    await coordinator.async_send_command(  # no local channel → cloud path
+        "dev-uuid:1", "VALVE_CONTROL", "STOP_UNTIL_NEXT_TASK"
+    )
+
+    throttle.assert_called_once()
+    increment.assert_called_once()
+    coordinator._client.async_send_command.assert_called_once()
+    assert coordinator.last_command_source("dev-uuid") == "cloud"
+
+
+async def test_local_command_works_when_cloud_budget_exhausted(
+    coordinator: GardenaCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    coordinator._local_channel = FakeChannel(connected=True, ack=True)  # type: ignore[assignment]
+    # If the cloud path were taken this would raise; the local path must not.
+    monkeypatch.setattr(
+        coordinator,
+        "check_command_throttle",
+        MagicMock(side_effect=HomeAssistantError("exhausted")),
+    )
+
+    await coordinator.async_send_command("dev-uuid:1", "VALVE_CONTROL", "STOP_UNTIL_NEXT_TASK")
+
+    assert coordinator.last_command_source("dev-uuid") == "local"
+    coordinator._client.async_send_command.assert_not_called()
 
 
 async def test_local_overlay_pushes_update_on_change(


### PR DESCRIPTION
## Summary
Local commands should not cost cloud API quota — but they did. Command **throttling** and **API-quota accounting** lived in the shared Gardena command-retry engine (`entity._async_execute_command`), which runs **before** the local/cloud routing decision. So a command carried over the local gateway still incremented the monthly budget by one, and — worse — `check_command_throttle()` raised on an exhausted budget, so **local commands were blocked when the cloud budget ran out**, defeating part of the point of local access.

## Fix
Move throttling + quota accounting into the **cloud branch** of `coordinator.async_send_command`:
- A command routed **locally** consumes **no quota**, is **not rate-limited**, and works **even with an exhausted cloud budget**.
- A **cloud** command still throttles + counts exactly once per attempt (retries included).
- The **Automower** command path (always cloud) is unchanged.

## Behaviour, now tested
- local command → `check_command_throttle` / `api_budget.increment` **not** called
- cloud command → both called once
- local command succeeds even when `check_command_throttle` would raise (exhausted)

## Quality
736 tests pass · **100% coverage** · `mypy --strict` clean · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)