### PR TITLE
fix: route deferred coordinator/aioautomower imports through HA's import executor

### DIFF
--- a/custom_components/gardena_smart_system_ng/__init__.py
+++ b/custom_components/gardena_smart_system_ng/__init__.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.importlib import async_import_module
 
 from .base_coordinator import BaseSmartSystemCoordinator
 from .const import (
@@ -19,6 +20,10 @@ from .const import (
     DOMAIN,
     GARDENA_PLATFORMS,
 )
+
+if TYPE_CHECKING:
+    from .automower_coordinator import AutomowerCoordinator
+    from .coordinator import GardenaCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,9 +37,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: GardenaConfigEntry) -> b
     api_type = entry.data.get(CONF_API_TYPE, API_TYPE_GARDENA)
 
     if api_type == API_TYPE_AUTOMOWER:
-        from .automower_coordinator import AutomowerCoordinator
-
-        am_coordinator = AutomowerCoordinator(hass, entry, session)
+        # These submodules are imported lazily (only the branch actually used
+        # by this config entry pulls in its client library) so a first-time
+        # import can still happen here, on the event loop. CPython's import
+        # machinery does blocking file I/O (stat/open/read) to resolve it, so
+        # it's routed through HA's dedicated import executor instead of a
+        # plain `from .automower_coordinator import AutomowerCoordinator`.
+        # See https://github.com/kayloehmann/ha-gardena-smart-system/issues/47
+        automower_coordinator_module = await async_import_module(
+            hass, f"{__name__}.automower_coordinator"
+        )
+        automower_coordinator_cls = cast(
+            "type[AutomowerCoordinator]",
+            automower_coordinator_module.AutomowerCoordinator,
+        )
+        am_coordinator = automower_coordinator_cls(hass, entry, session)
         await am_coordinator.api_budget.async_load()
         # Load persisted rate-limit state BEFORE first refresh — otherwise a
         # restart while the kill-switch is engaged would still issue an API
@@ -44,9 +61,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: GardenaConfigEntry) -> b
         entry.runtime_data = am_coordinator
         await hass.config_entries.async_forward_entry_setups(entry, AUTOMOWER_PLATFORMS)
     else:
-        from .coordinator import GardenaCoordinator
-
-        gd_coordinator = GardenaCoordinator(hass, entry, session)
+        # Same reasoning as above: `.coordinator` imports `.local_channel`,
+        # whose `gardena_smart_local_api` import triggers pydantic's lazy
+        # submodule loading — the exact import_module/listdir/read_text
+        # blocking calls reported in #47.
+        coordinator_module = await async_import_module(hass, f"{__name__}.coordinator")
+        coordinator_cls = cast("type[GardenaCoordinator]", coordinator_module.GardenaCoordinator)
+        gd_coordinator = coordinator_cls(hass, entry, session)
         await gd_coordinator.api_budget.async_load()
         await gd_coordinator.rate_limit_state.async_load()
         await gd_coordinator.async_config_entry_first_refresh()

--- a/custom_components/gardena_smart_system_ng/config_flow.py
+++ b/custom_components/gardena_smart_system_ng/config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 import voluptuous as vol
@@ -20,7 +20,9 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.importlib import async_import_module
 from homeassistant.helpers.selector import (
     BooleanSelector,
     NumberSelector,
@@ -35,6 +37,9 @@ from homeassistant.helpers.selector import (
 )
 
 from aiogardenasmart import GardenaAuth, GardenaClient
+
+if TYPE_CHECKING:
+    from aioautomower import AutomowerClient
 
 from .base_coordinator import async_reset_api_budget_store, async_reset_rate_limit_state_store
 from .const import (
@@ -175,7 +180,7 @@ class GardenaSmartSystemConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Validate Automower API access
                 session = async_get_clientsession(self.hass)
                 error = await self._async_test_automower(
-                    session, self._client_id, self._client_secret
+                    self.hass, session, self._client_id, self._client_secret
                 )
                 if error:
                     errors["base"] = error
@@ -232,7 +237,9 @@ class GardenaSmartSystemConfigFlow(ConfigFlow, domain=DOMAIN):
             api_type = entry.data.get(CONF_API_TYPE, API_TYPE_GARDENA)
 
             if api_type == API_TYPE_AUTOMOWER:
-                error = await self._async_test_automower(session, client_id, client_secret)
+                error = await self._async_test_automower(
+                    self.hass, session, client_id, client_secret
+                )
             else:
                 _, error = await self._async_test_gardena(session, client_id, client_secret)
 
@@ -288,7 +295,9 @@ class GardenaSmartSystemConfigFlow(ConfigFlow, domain=DOMAIN):
             api_type = entry.data.get(CONF_API_TYPE, API_TYPE_GARDENA)
 
             if api_type == API_TYPE_AUTOMOWER:
-                error = await self._async_test_automower(session, client_id, client_secret)
+                error = await self._async_test_automower(
+                    self.hass, session, client_id, client_secret
+                )
                 if not error:
                     if client_id != entry.data.get(CONF_CLIENT_ID):
                         await async_reset_api_budget_store(self.hass, entry.entry_id)
@@ -471,6 +480,7 @@ class GardenaSmartSystemConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     async def _async_test_automower(
+        hass: HomeAssistant,
         session: aiohttp.ClientSession,
         client_id: str,
         client_secret: str,
@@ -480,25 +490,26 @@ class GardenaSmartSystemConfigFlow(ConfigFlow, domain=DOMAIN):
         Always revokes the access token before returning so that repeated
         reauth/reconfigure attempts do not leave dangling tokens on the
         Husqvarna auth server.
-        """
-        from aioautomower.exceptions import (
-            AutomowerAuthenticationError,
-            AutomowerConnectionError,
-            AutomowerForbiddenError,
-            AutomowerRateLimitError,
-        )
 
-        from aioautomower import AutomowerClient
+        `aioautomower` may be imported for the first time in this process
+        right here (only users who pick the Automower branch ever trigger
+        it), so — like the deferred coordinator imports in ``__init__.py``
+        (see #47) — it's routed through HA's import executor instead of a
+        plain module-level/in-line import that would run on the event loop.
+        """
+        aioautomower_exceptions = await async_import_module(hass, "aioautomower.exceptions")
+        aioautomower_module = await async_import_module(hass, "aioautomower")
+        automower_client_cls = cast("type[AutomowerClient]", aioautomower_module.AutomowerClient)
 
         automower_error_map: dict[type[Exception], str] = {
-            AutomowerAuthenticationError: "invalid_auth",
-            AutomowerForbiddenError: "automower_not_connected",
-            AutomowerRateLimitError: "rate_limited",
-            AutomowerConnectionError: "cannot_connect",
+            aioautomower_exceptions.AutomowerAuthenticationError: "invalid_auth",
+            aioautomower_exceptions.AutomowerForbiddenError: "automower_not_connected",
+            aioautomower_exceptions.AutomowerRateLimitError: "rate_limited",
+            aioautomower_exceptions.AutomowerConnectionError: "cannot_connect",
         }
 
         auth = GardenaAuth(client_id, client_secret, session)
-        client = AutomowerClient(auth, session)
+        client = automower_client_cls(auth, session)
         try:
             try:
                 await client.async_get_mowers()

--- a/tests/components/gardena_smart_system_ng/test_config_flow_coverage.py
+++ b/tests/components/gardena_smart_system_ng/test_config_flow_coverage.py
@@ -47,6 +47,42 @@ async def test_automower_credential_test_swallows_revoke_error(
         patch("aioautomower.AutomowerClient", return_value=client),
     ):
         error = await GardenaSmartSystemConfigFlow._async_test_automower(
-            async_get_clientsession(hass), "id", "secret"
+            hass, async_get_clientsession(hass), "id", "secret"
         )
     assert error == ""  # revoke failure is logged, not raised
+
+
+async def test_automower_credential_test_routes_import_through_executor(
+    hass: HomeAssistant,
+) -> None:
+    """Regression test for #47 ("Detected blocking call").
+
+    `aioautomower` (and its `.exceptions` submodule) may be imported for the
+    first time in this process inside `_async_test_automower` — the same
+    anti-pattern as the deferred coordinator imports in `__init__.py`. This
+    asserts the fix (routing through
+    `homeassistant.helpers.importlib.async_import_module`) is actually used.
+    """
+    from homeassistant.helpers.importlib import (
+        async_import_module as real_async_import_module,
+    )
+
+    auth = MagicMock()
+    auth.async_revoke_token = AsyncMock()
+    client = MagicMock()
+    client.async_get_mowers = AsyncMock(return_value=[])
+    with (
+        patch(f"{_CF}.GardenaAuth", return_value=auth),
+        patch("aioautomower.AutomowerClient", return_value=client),
+        patch(
+            f"{_CF}.async_import_module",
+            AsyncMock(wraps=real_async_import_module),
+        ) as mock_import,
+    ):
+        error = await GardenaSmartSystemConfigFlow._async_test_automower(
+            hass, async_get_clientsession(hass), "id", "secret"
+        )
+
+    assert error == ""
+    mock_import.assert_any_await(hass, "aioautomower")
+    mock_import.assert_any_await(hass, "aioautomower.exceptions")

--- a/tests/components/gardena_smart_system_ng/test_init.py
+++ b/tests/components/gardena_smart_system_ng/test_init.py
@@ -17,6 +17,7 @@ except ImportError:
     )
 
 from custom_components.gardena_smart_system_ng.const import (
+    API_TYPE_AUTOMOWER,
     API_TYPE_GARDENA,
     CONF_API_TYPE,
     CONF_CLIENT_ID,
@@ -121,6 +122,90 @@ class TestSetupEntry:
             await hass.async_block_till_done()
 
         assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+class TestSetupEntryUsesImportExecutor:
+    """Regression test for #47 ("Detected blocking call").
+
+    The coordinator submodules are imported lazily (only the branch actually
+    used by a given config entry pulls in its client library), which used to
+    be a plain `from .coordinator import GardenaCoordinator` executed inside
+    the async `async_setup_entry` — i.e. on the event loop. CPython's import
+    machinery does blocking file I/O to resolve a module the first time it's
+    imported in the process, which is exactly what HA's blocking-call
+    detector caught. The fix routes these imports through HA's dedicated
+    import executor via `homeassistant.helpers.importlib.async_import_module`
+    instead. These tests assert that mechanism is actually used, not just
+    that setup still happens to work.
+    """
+
+    async def test_gardena_setup_routes_coordinator_import_through_executor(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: object,
+        mock_api: object,
+    ) -> None:
+        from homeassistant.helpers.importlib import (
+            async_import_module as real_async_import_module,
+        )
+
+        with patch(
+            "custom_components.gardena_smart_system_ng.async_import_module",
+            AsyncMock(wraps=real_async_import_module),
+        ) as mock_import:
+            mock_config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert mock_config_entry.state is ConfigEntryState.LOADED
+        mock_import.assert_awaited_once_with(
+            hass, "custom_components.gardena_smart_system_ng.coordinator"
+        )
+
+    async def test_automower_setup_routes_coordinator_import_through_executor(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        from homeassistant.helpers.importlib import (
+            async_import_module as real_async_import_module,
+        )
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={**ENTRY_DATA, CONF_API_TYPE: API_TYPE_AUTOMOWER},
+            title="Mower",
+            version=2,
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            patch(
+                "custom_components.gardena_smart_system_ng.async_import_module",
+                AsyncMock(wraps=real_async_import_module),
+            ) as mock_import,
+            patch(
+                "custom_components.gardena_smart_system_ng.automower_coordinator.AutomowerClient"
+            ) as mock_client_cls,
+            patch(
+                "custom_components.gardena_smart_system_ng.automower_coordinator.GardenaAuth",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "custom_components.gardena_smart_system_ng.automower_coordinator.AutomowerWebSocket"
+            ) as mock_ws_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.async_get_mowers = AsyncMock(return_value={})
+            mock_client_cls.return_value = mock_client
+            mock_ws_cls.return_value = AsyncMock()
+
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert entry.state is ConfigEntryState.LOADED
+        mock_import.assert_awaited_once_with(
+            hass, "custom_components.gardena_smart_system_ng.automower_coordinator"
+        )
 
 
 class TestUnloadEntry:


### PR DESCRIPTION
## Summary

Fixes #47 ("Detected blocking call to import_module ... by custom
integration 'gardena_smart_system_ng' at
`custom_components/gardena_smart_system_ng/local_channel.py`, line 35").

- `async_setup_entry` in `__init__.py` picked its coordinator class with a
  plain `from .coordinator import GardenaCoordinator` /
  `from .automower_coordinator import AutomowerCoordinator` executed
  *inside* the async setup function — i.e. on the event loop. The first
  import of `.coordinator` pulls in `.local_channel`, whose
  `gardena_smart_local_api` import triggers pydantic's lazy submodule
  loading, which does blocking file I/O (`import_module`/`listdir`/
  `read_text`). That's exactly the chain HA's blocking-call detector
  reported in #47.
- Fixed by routing both deferred imports through
  `homeassistant.helpers.importlib.async_import_module`, which HA ships
  specifically for this situation: it imports on the dedicated import
  executor thread (with a cheap `sys.modules` cache-hit fast path for
  subsequent config entries) instead of on the event loop.
- Found and fixed the same anti-pattern in `config_flow.py`'s
  `_async_test_automower` (deferred `aioautomower` import inside an async
  config-flow step) while I was in there — same root cause, same fix,
  separate commit.

Two atomic commits: the direct #47 fix, then the analogous config_flow.py
fix.

## Test plan

- [x] `ruff check custom_components/ tests/` — clean
- [x] `ruff format --check custom_components/ tests/` — clean
- [x] `mypy custom_components/gardena_smart_system_ng/` (strict) — no issues, 36 files
- [x] Full test suite: `pytest --cov` — 739 passed, 100% coverage maintained
- [x] Added regression tests asserting `async_import_module` is actually
      invoked for both the Gardena and Automower coordinator branches, and
      for the `aioautomower` credential test — not just that setup still
      happens to work

**Not merging** — flagging for review per request; this only needs a
merge decision, no further changes expected unless review turns something
up.