### PR TITLE
ci: run the vendored libraries' test-suites (and fix them)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,51 @@ jobs:
           args: format --check custom_components/ tests/
           src: "."
 
+  libs:
+    # The vendored libraries ship their own test-suites, but the root pytest run
+    # cannot see them (`testpaths = ["tests"]`), and the lint/mypy jobs above are
+    # scoped to `custom_components/` + `tests/`. They were therefore completely
+    # unverified in CI — this job closes that gap. Each library is checked in a
+    # clean environment, exactly as a downstream consumer would install it from
+    # PyPI, and NOT inside the Home Assistant test environment (whose pinned
+    # dependency set would mask what a standalone install actually resolves).
+    name: Vendored library (${{ matrix.lib }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: [aiogardenasmart, aiohusqvarna]
+    defaults:
+      run:
+        working-directory: ${{ matrix.lib }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        working-directory: .
+        # `aiohusqvarna` depends on `aiogardenasmart`. Install both from the tree
+        # so we test the source we are about to ship — never a release that pip
+        # would otherwise pull from PyPI.
+        run: |
+          pip install -e ./aiogardenasmart -e ./aiohusqvarna
+          pip install -e "./${{ matrix.lib }}[dev]"
+
+      - name: Ruff
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Run mypy
+        run: mypy src/
+
+      - name: Run tests
+        run: pytest -q
+
   test:
     name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Gardena Smart System integration for Home Assistant.
 
 ## [Unreleased]
 
+### Changed
+- **The vendored libraries are now actually verified in CI.** `aiogardenasmart` and `aiohusqvarna` each ship their own test-suite, but no CI job ever ran them: the root pytest run is scoped to `testpaths = ["tests"]`, and the lint/mypy jobs are scoped to `custom_components/` + `tests/`. Both libraries were therefore untested, unlinted and un-typechecked in CI — while being published to PyPI and pinned in `manifest.json`. A new `libs` job runs ruff, mypy and pytest for each library in a **clean, standalone environment** (not inside the Home Assistant test environment, whose pinned dependency set would mask what a standalone install actually resolves).
+
+### Fixed
+- **The library test-suites were broken and nobody could tell.** Because nothing ran them, it went unnoticed that `aioresponses` 0.7.9 (its latest release) is incompatible with `aiohttp` 3.14 — which is what Home Assistant ships: `aiohttp` made `stream_writer` a required argument of `ClientResponse.__init__`, so every mocked request raised `TypeError`. `aioresponses` declares `aiohttp<4.0,>=3.8`, so pip resolves the broken combination happily. Upstream has open PRs ([#288](https://github.com/pnuckowski/aioresponses/pull/288), [#292](https://github.com/pnuckowski/aioresponses/pull/292)) but no release, so both suites carry a small, signature-guarded compatibility shim in `tests/conftest.py`. The shim turns itself into a no-op as soon as a fixed `aioresponses` is released. Pinning `aiohttp<3.14` for tests was rejected on purpose: it would test the libraries against an aiohttp that Home Assistant does not run. No runtime behaviour changed — this is test/CI scaffolding only.
+
 ## [2.1.2] - 2026-07-13
 
 ### Fixed

--- a/aiogardenasmart/tests/conftest.py
+++ b/aiogardenasmart/tests/conftest.py
@@ -1,0 +1,58 @@
+"""Shared pytest configuration for the aiogardenasmart test-suite.
+
+This module carries a narrowly scoped compatibility shim for ``aioresponses``.
+
+``aiohttp`` 3.14 turned ``stream_writer`` into a *required* keyword-only
+argument of ``ClientResponse.__init__``. ``aioresponses`` (0.7.9, the latest
+release at the time of writing) still builds its mocked responses without it,
+so every mocked request raises::
+
+    TypeError: ClientResponse.__init__() missing 1 required
+               keyword-only argument: 'stream_writer'
+
+``aioresponses`` declares ``aiohttp<4.0,>=3.8``, so pip happily resolves the
+broken combination. Upstream has open pull requests for this (pnuckowski/
+aioresponses#288 and #292) but no release yet.
+
+Pinning ``aiohttp<3.14`` for tests would be the cheap way out, but it would
+test this library against an aiohttp that Home Assistant does *not* ship
+(HA 2026.2 runs aiohttp 3.14.1) — precisely the kind of gap that lets a real
+bug through a green CI. So instead we apply upstream's fix ourselves, at the
+smallest possible surface: a ``ClientResponse`` subclass that defaults the new
+argument. ``stream_writer`` is only consulted for its ``output_size``
+attribute, so a mock is sufficient.
+
+The shim is guarded by a signature check and therefore becomes a no-op the
+moment aioresponses ships a fixed release (or on any older aiohttp). Remove
+this file once ``aioresponses > 0.7.9`` is available and pinned in the dev
+dependencies.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import Mock
+
+import aioresponses.core
+from aiohttp.client_reqrep import ClientResponse
+
+
+def _client_response_requires_stream_writer() -> bool:
+    """Return True if ``ClientResponse`` demands a ``stream_writer`` argument."""
+    parameter = inspect.signature(ClientResponse.__init__).parameters.get("stream_writer")
+    return parameter is not None and parameter.default is inspect.Parameter.empty
+
+
+class _ClientResponseWithStreamWriter(ClientResponse):
+    """``ClientResponse`` that supplies the aiohttp 3.14 ``stream_writer`` argument."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("stream_writer", Mock(output_size=0))
+        super().__init__(*args, **kwargs)
+
+
+if _client_response_requires_stream_writer():
+    # `aioresponses.core` imports `ClientResponse` into its own namespace and
+    # resolves it at call time, so rebinding the module global is enough.
+    aioresponses.core.ClientResponse = _ClientResponseWithStreamWriter  # type: ignore[misc]

--- a/aiohusqvarna/tests/conftest.py
+++ b/aiohusqvarna/tests/conftest.py
@@ -1,0 +1,58 @@
+"""Shared pytest configuration for the aiohusqvarna test-suite.
+
+This module carries a narrowly scoped compatibility shim for ``aioresponses``.
+
+``aiohttp`` 3.14 turned ``stream_writer`` into a *required* keyword-only
+argument of ``ClientResponse.__init__``. ``aioresponses`` (0.7.9, the latest
+release at the time of writing) still builds its mocked responses without it,
+so every mocked request raises::
+
+    TypeError: ClientResponse.__init__() missing 1 required
+               keyword-only argument: 'stream_writer'
+
+``aioresponses`` declares ``aiohttp<4.0,>=3.8``, so pip happily resolves the
+broken combination. Upstream has open pull requests for this (pnuckowski/
+aioresponses#288 and #292) but no release yet.
+
+Pinning ``aiohttp<3.14`` for tests would be the cheap way out, but it would
+test this library against an aiohttp that Home Assistant does *not* ship
+(HA 2026.2 runs aiohttp 3.14.1) — precisely the kind of gap that lets a real
+bug through a green CI. So instead we apply upstream's fix ourselves, at the
+smallest possible surface: a ``ClientResponse`` subclass that defaults the new
+argument. ``stream_writer`` is only consulted for its ``output_size``
+attribute, so a mock is sufficient.
+
+The shim is guarded by a signature check and therefore becomes a no-op the
+moment aioresponses ships a fixed release (or on any older aiohttp). Remove
+this file once ``aioresponses > 0.7.9`` is available and pinned in the dev
+dependencies.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import Mock
+
+import aioresponses.core
+from aiohttp.client_reqrep import ClientResponse
+
+
+def _client_response_requires_stream_writer() -> bool:
+    """Return True if ``ClientResponse`` demands a ``stream_writer`` argument."""
+    parameter = inspect.signature(ClientResponse.__init__).parameters.get("stream_writer")
+    return parameter is not None and parameter.default is inspect.Parameter.empty
+
+
+class _ClientResponseWithStreamWriter(ClientResponse):
+    """``ClientResponse`` that supplies the aiohttp 3.14 ``stream_writer`` argument."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("stream_writer", Mock(output_size=0))
+        super().__init__(*args, **kwargs)
+
+
+if _client_response_requires_stream_writer():
+    # `aioresponses.core` imports `ClientResponse` into its own namespace and
+    # resolves it at call time, so rebinding the module global is enough.
+    aioresponses.core.ClientResponse = _ClientResponseWithStreamWriter  # type: ignore[misc]


### PR DESCRIPTION
## Problem

Both vendored libraries ship their own test-suites — and **no CI job ever ran them**:

- the root pytest run is scoped to `testpaths = ["tests"]` (root `pyproject.toml`), so it never collects `aiogardenasmart/tests/` or `aiohusqvarna/tests/`;
- the `lint` and `mypy` jobs pass explicit `custom_components/ tests/` paths.

So both libraries were **untested, unlinted and un-typechecked in CI** — while being published to PyPI and pinned in `manifest.json`. This is the same class of gap that let the missing `aioautomower` requirement ship in #50.

## …and because nothing ran them, they were quietly broken

`aioresponses` **0.7.9 — its latest release** — is incompatible with `aiohttp` **3.14**, which is what Home Assistant ships (HA 2026.2 → aiohttp 3.14.1). aiohttp made `stream_writer` a *required* keyword-only argument of `ClientResponse.__init__`; aioresponses still builds its mocked responses without it:

```
TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
```

`aioresponses` declares `aiohttp<4.0,>=3.8`, so pip resolves the broken combination without complaint. Upstream has open PRs ([#288](https://github.com/pnuckowski/aioresponses/pull/288), [#292](https://github.com/pnuckowski/aioresponses/pull/292)) but **no release**.

On a clean checkout today, `aiogardenasmart`'s suite is **12 failed / 16 errors**.

## Changes

**1. New `libs` CI job** (matrix over `aiogardenasmart`, `aiohusqvarna`) — runs `ruff check` + `ruff format --check`, `mypy src/` and `pytest` for each library.

It runs in a **clean, standalone environment**, deliberately *not* inside the Home Assistant test environment: HA's pinned dependency set would mask what a standalone `pip install` actually resolves — which is exactly how this bug stayed invisible. Both libraries are installed editable from the tree, so we test the source we're about to ship, never a release pip would otherwise pull from PyPI.

**2. aioresponses compatibility shim** in each suite's `tests/conftest.py`, mirroring upstream's fix: a `ClientResponse` subclass that defaults the new argument. It is guarded by a signature check, so it becomes a **no-op** the moment a fixed `aioresponses` is released (or on any older aiohttp).

Pinning `aiohttp<3.14` for tests was rejected on purpose — it would test the libraries against an aiohttp that Home Assistant does not run, which is precisely the kind of gap that lets a real bug through a green CI. (`aiohusqvarna` also requires `aiohttp>=3.14.1` at runtime, so the pin would conflict outright.)

## Verification

Reproduced the new CI job locally — clean venv, same install commands, all four steps:

| | ruff | mypy | pytest |
|---|---|---|---|
| `aiogardenasmart` | ✅ | ✅ 7 files | ✅ **104 passed** |
| `aiohusqvarna` | ✅ | ✅ 6 files | ✅ **30 passed** |

Counter-checked that the job has teeth: **remove the shim → `12 failed, 16 errors`.**

Root suite unaffected: **739 passed**, ruff + mypy clean.

**No runtime behaviour changed — test/CI scaffolding only.** No release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)